### PR TITLE
docs: main-pin the annotation GIF and document the label-offset edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Annotate a plot with callouts, reference lines and shaded windows, and both the 
 and Markdown generators render them — here the code, then the plots it produced:
 
 <p align="center">
-  <!-- Pinned to the commit that added this asset, not to main: a main-pinned URL
-       404s (rendering as blank space) on every branch and fork until the file
-       reaches main, which makes the image unreviewable before merge. Bump the SHA
-       when regenerating the GIF, or the README keeps showing the old one. -->
-  <img src="https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/96d89e846ada8a2ef28623a624a7ba0a9173ca2b/docs/images/plot-annotations.gif" alt="Code adding four plot annotations — a vertical line, a label, a horizontal reference line and a shaded span — to a captured waveform, followed by the two plots that code produced: the full trace and a region zoom inheriting the same annotations" width="760">
+  <!-- Same main-pinned form as the hero above, so regenerating the GIF updates
+       this automatically. Worth knowing when adding a NEW image: a main-pinned URL
+       404s until the file reaches main, and GitHub renders that as blank space
+       rather than a broken-image icon, so it cannot be reviewed on the branch that
+       adds it. Pin such an image to its commit SHA until merge, then switch here. -->
+  <img src="https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/plot-annotations.gif" alt="Code adding four plot annotations — a vertical line, a label, a horizontal reference line and a shaded span — to a captured waveform, followed by the two plots that code produced: the full trace and a region zoom inheriting the same annotations" width="760">
 </p>
 
 <!-- annotation-snippet: byte-for-byte the SNIPPET that scripts/media/make_annotation_gif.py

--- a/docs/report-generator/getting-started.md
+++ b/docs/report-generator/getting-started.md
@@ -372,6 +372,15 @@ same file twice does not duplicate them.
 - **Overlapping labels are not auto-spaced.** If two labels land on top of each
   other, nudge one with `text_dx`/`text_dy` (offsets from the anchor, as a fraction
   of the axis span) rather than expecting automatic layout.
+- **Label offsets are not clamped to the plot area.** `text_dx`/`text_dy` are applied
+  as-is, and matplotlib does not grow the axes to fit annotation text, so an offset
+  that lands outside the data range puts the text outside the plot box — a large
+  positive `text_dy` on a label near the top of the trace typically collides with the
+  plot title. Only the label kind takes offsets at all: vertical-line and span text is
+  pinned just inside the top of the axes, and horizontal-line text to the right edge at
+  its own line's height, so those stay within the plot box. Keep label offsets small
+  (the 0.06 default is roughly the right scale) and check the rendered plot rather
+  than assuming a big offset will be reined in.
 - **A literal `*` or `_` in a caption can corrupt the surrounding emphasis markup, in
   both PDF and Markdown reports.** Both formats deliberately interpret `*text*` and
   `_text_` in a caption as emphasis — the Markdown generator emits captions


### PR DESCRIPTION
Closes the two loose ends left by #155. Docs only — no behaviour change, no new tests needed (the existing README/GIF drift guards cover the touched block and still pass).

## 1. The annotation GIF returns to a main-pinned URL

It was pinned to the commit that added it so the image could be reviewed on the branch: a `main`-pinned URL 404s until the file reaches `main`, and **GitHub renders that as blank space, not a broken-image icon**, so the image is invisible exactly when it needs reviewing. That rationale expired on merge, and the SHA form needs a manual bump every time the GIF is regenerated, so this restores the `main` pin the hero GIF uses.

The comment now records when a SHA pin *is* the right move, rather than just asserting the current choice — the failure mode it avoids is silent, so the next person adding an image would otherwise rediscover it the same way.

## 2. Documents the label-offset edge

`text_dx`/`text_dy` are applied as-is, and matplotlib does not grow the axes to fit annotation text, so an offset landing outside the data range puts the text outside the plot box — a large positive `text_dy` near the top of a trace typically collides with the plot title. This showed up while exercising every annotation surface for `report_annotations_advanced.py`.

The guide already covered label-vs-label collisions ("overlapping labels are not auto-spaced") but not label-vs-axes-edge, which reads as a rendering bug rather than a positioning choice when you hit it. Added to the same limitations list, with the scope stated: only labels take offsets, while vertical-line and span text is pinned just inside the top of the axes and horizontal-line text to the right edge at its own line's height, so those stay inside the box.

**Not fixed, deliberately.** Clamping label text into the axes would change where existing annotations render and quietly override an explicit user offset. It is a reasonable future change, but it is a behaviour decision rather than a doc gap, and this repo's annotation docs already treat user-controlled positioning as documented limitations.

## Testing

`pytest -m "not slow" -n 8` → 2804 passed, 19 skipped.
