### PR TITLE
fix(report): sanitize/escape report-generator text output (H24-H27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading is per-transfer, not per-point. What changed is resolution
   (2000 → up to 100 000 samples per frame), not rate.
 
+### Security
+
+- **Report-text-derived plot filenames could escape the plots directory.**
+  A section title or channel label containing `..`, `/` or `:` reached the
+  saved PNG's filename unsanitized — on Windows, a `:` could silently write
+  to an NTFS alternate data stream instead of the intended file, and a `/`
+  or `..` could crash generation or write outside the report's plots
+  folder. Filenames are now built from an allowlist of the derived text,
+  with a second check confirming the resolved path stays under the plots
+  directory before anything is written.
+- **PDF report text reached ReportLab's markup parser unescaped at most
+  call sites.** Titles, section headings, channel labels, and comparison
+  table titles were passed straight to ReportLab's `Paragraph`, which
+  parses its input as XML mini-markup — a `<`, `>` or `&` in any of them
+  could corrupt the page or silently drop content. Every text construction
+  in the PDF generator now routes through one escaping helper.
+
 ### Changed
 
 - Scope sessions no longer sit on a fixed quarter-second poll floor: the floor
@@ -64,6 +81,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `svglib` already reads. PDF plots now render both at the alpha they were drawn
   with. Markdown reports were always correct, so PDF and Markdown output of the
   same report now match.
+- **A code span next to bold text could corrupt or crash PDF generation.**
+  The internal placeholder used to protect `` `code` `` spans while
+  markdown was converted to PDF markup was itself shaped like the bold
+  markdown it was being protected from, so the two collided. An AI-written
+  summary mixing a code span with `**bold**` text — an ordinary shape for
+  an LLM to produce — now renders both correctly instead of losing the
+  code span or failing generation outright.
+- **AI-generated summary/findings could ship into a report built from
+  different data than they described.** The AI Analysis panel's generated
+  content stayed attached after starting a new report or importing new
+  waveforms, so a report built afterward could silently include narrative
+  text about a previous dataset. It's now cleared whenever the underlying
+  waveforms change.
 
 ### Removed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -42,6 +42,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading is per-transfer, not per-point. What changed is resolution
   (2000 → up to 100 000 samples per frame), not rate.
 
+### Security
+
+- **Report-text-derived plot filenames could escape the plots directory.**
+  A section title or channel label containing `..`, `/` or `:` reached the
+  saved PNG's filename unsanitized — on Windows, a `:` could silently write
+  to an NTFS alternate data stream instead of the intended file, and a `/`
+  or `..` could crash generation or write outside the report's plots
+  folder. Filenames are now built from an allowlist of the derived text,
+  with a second check confirming the resolved path stays under the plots
+  directory before anything is written.
+- **PDF report text reached ReportLab's markup parser unescaped at most
+  call sites.** Titles, section headings, channel labels, and comparison
+  table titles were passed straight to ReportLab's `Paragraph`, which
+  parses its input as XML mini-markup — a `<`, `>` or `&` in any of them
+  could corrupt the page or silently drop content. Every text construction
+  in the PDF generator now routes through one escaping helper.
+
 ### Changed
 
 - Scope sessions no longer sit on a fixed quarter-second poll floor: the floor
@@ -64,6 +81,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `svglib` already reads. PDF plots now render both at the alpha they were drawn
   with. Markdown reports were always correct, so PDF and Markdown output of the
   same report now match.
+- **A code span next to bold text could corrupt or crash PDF generation.**
+  The internal placeholder used to protect `` `code` `` spans while
+  markdown was converted to PDF markup was itself shaped like the bold
+  markdown it was being protected from, so the two collided. An AI-written
+  summary mixing a code span with `**bold**` text — an ordinary shape for
+  an LLM to produce — now renders both correctly instead of losing the
+  code span or failing generation outright.
+- **AI-generated summary/findings could ship into a report built from
+  different data than they described.** The AI Analysis panel's generated
+  content stayed attached after starting a new report or importing new
+  waveforms, so a report built afterward could silently include narrative
+  text about a previous dataset. It's now cleared whenever the underlying
+  waveforms change.
 
 ### Removed
 

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -6,6 +6,7 @@ converted to other formats, or committed to documentation repositories.
 """
 
 import logging
+import re
 from pathlib import Path
 from typing import List, Optional
 
@@ -442,6 +443,20 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
         return "\n".join(lines)
 
+    _FILENAME_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+    def _sanitize_plot_name(self, name: str) -> str:
+        """Allowlist a report-text-derived string for use in a filename.
+
+        Report text (section titles, channel labels parsed from imported run
+        files) reaches this class's plot-filename construction directly;
+        without sanitizing it a title like '../../etc/x' can escape
+        plots_path, '/' crashes the write, and ':' collides with NTFS
+        alternate-data-stream syntax (AUDIT.md H24).
+        """
+        sanitized = self._FILENAME_SAFE.sub("_", name)
+        return sanitized or "plot"
+
     def _generate_region_plot(self, waveform: WaveformData, region, base_path: Path, name: str) -> Optional[str]:
         """
         Generate and save a zoomed plot for a region.
@@ -461,8 +476,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
             plots_path = base_path / self.plots_dir
             plots_path.mkdir(parents=True, exist_ok=True)
 
-            filename = f"{name.replace(' ', '_')}.png"
+            filename = f"{self._sanitize_plot_name(name)}.png"
             filepath = plots_path / filename
+            if not filepath.resolve().is_relative_to(plots_path.resolve()):
+                raise ValueError(f"resolved plot path {filepath} escapes {plots_path}")
 
             # Extract region data
             t, v = waveform.get_region_data(region)
@@ -549,8 +566,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
         plots_path = base_path / self.plots_dir
         plots_path.mkdir(parents=True, exist_ok=True)
 
-        filename = f"{name.replace(' ', '_')}.png"
+        filename = f"{self._sanitize_plot_name(name)}.png"
         filepath = plots_path / filename
+        if not filepath.resolve().is_relative_to(plots_path.resolve()):
+            raise ValueError(f"resolved plot path {filepath} escapes {plots_path}")
 
         # Apply matplotlib style preset
         if self.plot_style.matplotlib_style != "default":
@@ -582,8 +601,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
         plots_path = base_path / self.plots_dir
         plots_path.mkdir(parents=True, exist_ok=True)
 
-        filename = f"{name.replace(' ', '_')}_fft.png"
+        filename = f"{self._sanitize_plot_name(name)}_fft.png"
         filepath = plots_path / filename
+        if not filepath.resolve().is_relative_to(plots_path.resolve()):
+            raise ValueError(f"resolved plot path {filepath} escapes {plots_path}")
 
         # Apply matplotlib style preset
         if self.plot_style.matplotlib_style != "default":
@@ -650,8 +671,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
         try:
             plots_path = base_path / self.plots_dir
             plots_path.mkdir(parents=True, exist_ok=True)
-            filename = f"{name.replace(' ', '_')}.png"
+            filename = f"{self._sanitize_plot_name(name)}.png"
             filepath = plots_path / filename
+            if not filepath.resolve().is_relative_to(plots_path.resolve()):
+                raise ValueError(f"resolved plot path {filepath} escapes {plots_path}")
 
             if self.plot_style.matplotlib_style != "default":
                 plt.style.use(self.plot_style.matplotlib_style)

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -404,6 +404,24 @@ class PDFReportGenerator(BaseReportGenerator):
 
         return escape(text or "")
 
+    def _para(self, text: str, style, mode: str = "markdown") -> Paragraph:
+        """The only place a Paragraph flowable is constructed in this file.
+
+        mode="markdown": run through _markdown_to_reportlab (bold/italic/
+            code spans supported -- for AI/user prose).
+        mode="literal": run through _literal_cell_text (no markdown
+            interpretation -- for titles/names/labels, which shouldn't
+            support bold/italic anyway).
+        mode="preformatted": text is already escaped/composited by the
+            caller (its XML tags are ours, not user text) -- pass through
+            unchanged.
+        """
+        if mode == "preformatted":
+            escaped = text
+        else:
+            escaped = self._markdown_to_reportlab(text) if mode == "markdown" else self._literal_cell_text(text)
+        return Paragraph(escaped, style)
+
     def generate(self, report: TestReport, output_path: Path) -> bool:
         """
         Generate PDF report.
@@ -543,11 +561,11 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Company name
         if report.metadata.company_name:
-            story.append(Paragraph(report.metadata.company_name, self.styles["Normal"]))
+            story.append(self._para(report.metadata.company_name, self.styles["Normal"], mode="literal"))
             story.append(Spacer(1, 0.1 * inch))
 
         # Title
-        story.append(Paragraph(report.metadata.title, self.styles["ReportTitle"]))
+        story.append(self._para(report.metadata.title, self.styles["ReportTitle"], mode="literal"))
         story.append(Spacer(1, 0.3 * inch))
 
         return story
@@ -619,9 +637,11 @@ class PDFReportGenerator(BaseReportGenerator):
             text = f"<b>Overall Result: FAIL</b>"
         else:
             style = self.styles["Normal"]
-            text = f"<b>Overall Result: {overall}</b>"
+            # overall_result is a public TestReport field -- nothing constrains it
+            # to PASS/FAIL/INCONCLUSIVE, so it must be escaped like any other text.
+            text = f"<b>Overall Result: {self._literal_cell_text(overall)}</b>"
 
-        story.append(Paragraph(text, style))
+        story.append(self._para(text, style, mode="preformatted"))
 
         # Measurement summary
         measurements = report.get_all_measurements()
@@ -630,7 +650,7 @@ class PDFReportGenerator(BaseReportGenerator):
             failed = sum(1 for m in measurements if m.passed is False)
 
             summary_text = f"Measurements: {len(measurements)} total, {passed} passed, {failed} failed"
-            story.append(Paragraph(summary_text, self.styles["Normal"]))
+            story.append(self._para(summary_text, self.styles["Normal"], mode="preformatted"))
             story.append(Spacer(1, 0.2 * inch))
 
         return story
@@ -639,16 +659,16 @@ class PDFReportGenerator(BaseReportGenerator):
         """Generate executive summary section."""
         story = []
 
-        story.append(Paragraph("Executive Summary", self.styles["SectionHeading"]))
+        story.append(self._para("Executive Summary", self.styles["SectionHeading"], mode="preformatted"))
 
-        # Convert markdown to ReportLab XML
-        summary_text = self._markdown_to_reportlab(report.executive_summary)
-        story.append(Paragraph(summary_text, self.styles["Normal"]))
+        story.append(self._para(report.executive_summary, self.styles["Normal"], mode="markdown"))
 
+        # summary_attribution() returns one of two fixed, hardcoded strings or
+        # None (see ReportMetadata.summary_attribution) -- never user text.
         attribution = report.summary_attribution()
         if attribution:
             story.append(Spacer(1, 0.1 * inch))
-            story.append(Paragraph(f"<i>{attribution}</i>", self.styles["Normal"]))
+            story.append(self._para(f"<i>{attribution}</i>", self.styles["Normal"], mode="preformatted"))
 
         story.append(Spacer(1, 0.2 * inch))
 
@@ -658,17 +678,16 @@ class PDFReportGenerator(BaseReportGenerator):
         """Generate key findings section."""
         story = []
 
-        story.append(Paragraph("Key Findings", self.styles["SectionHeading"]))
+        story.append(self._para("Key Findings", self.styles["SectionHeading"], mode="preformatted"))
 
         for finding in report.key_findings:
-            # Convert markdown to ReportLab XML
             finding_text = self._markdown_to_reportlab(finding)
-            story.append(Paragraph(f"• {finding_text}", self.styles["Normal"]))
+            story.append(self._para(f"• {finding_text}", self.styles["Normal"], mode="preformatted"))
 
         findings_attribution = report.findings_attribution()
         if findings_attribution:
             story.append(Spacer(1, 0.1 * inch))
-            story.append(Paragraph(f"<i>{findings_attribution}</i>", self.styles["Normal"]))
+            story.append(self._para(f"<i>{findings_attribution}</i>", self.styles["Normal"], mode="preformatted"))
 
         story.append(Spacer(1, 0.2 * inch))
 
@@ -686,26 +705,24 @@ class PDFReportGenerator(BaseReportGenerator):
         """Generate a report section with progress tracking."""
         story = []
 
-        story.append(Paragraph(section.title, self.styles["SectionHeading"]))
+        story.append(self._para(section.title, self.styles["SectionHeading"], mode="literal"))
 
         if section.content:
-            content_text = section.content.replace("\n", "<br/>")
-            story.append(Paragraph(content_text, self.styles["Normal"]))
+            # mode="markdown" handles the \n -> <br/> conversion as part of
+            # its existing pipeline (it was previously done manually here,
+            # unescaped, before the text ever reached the Paragraph flowable).
+            story.append(self._para(section.content, self.styles["Normal"], mode="markdown"))
             story.append(Spacer(1, 0.1 * inch))
 
         # AI insights
         if section.ai_summary:
-            story.append(Paragraph("AI Analysis", self.styles["SubsectionHeading"]))
-            # Normalize Unicode characters from AI-generated text
-            ai_text = self._markdown_to_reportlab(section.ai_summary)
-            story.append(Paragraph(ai_text, self.styles["Normal"]))
+            story.append(self._para("AI Analysis", self.styles["SubsectionHeading"], mode="preformatted"))
+            story.append(self._para(section.ai_summary, self.styles["Normal"], mode="markdown"))
             story.append(Spacer(1, 0.1 * inch))
 
         if section.ai_insights:
-            story.append(Paragraph("AI Insights", self.styles["SubsectionHeading"]))
-            # Normalize Unicode characters from AI-generated text
-            insights_text = self._markdown_to_reportlab(section.ai_insights)
-            story.append(Paragraph(insights_text, self.styles["Normal"]))
+            story.append(self._para("AI Insights", self.styles["SubsectionHeading"], mode="preformatted"))
+            story.append(self._para(section.ai_insights, self.styles["Normal"], mode="markdown"))
             story.append(Spacer(1, 0.1 * inch))
 
         # Overlay plots (comparison/batch)
@@ -714,21 +731,22 @@ class PDFReportGenerator(BaseReportGenerator):
                 drawing = self._generate_overlay_plot(spec)
                 if drawing is not None:
                     channel_label = self._markdown_to_reportlab(spec.channel_label)
-                    grouped = [Paragraph(f"Channel {channel_label} — all runs", self.styles["SubsectionHeading"]), drawing]
+                    heading = self._para(f"Channel {channel_label} — all runs", self.styles["SubsectionHeading"], mode="preformatted")
+                    grouped = [heading, drawing]
                     if spec.caption:
-                        grouped.append(Paragraph(self._markdown_to_reportlab(spec.caption), self.styles["FigureCaption"]))
+                        grouped.append(self._para(spec.caption, self.styles["FigureCaption"], mode="markdown"))
                     story.append(KeepTogether(grouped))
                     story.append(Spacer(1, 0.1 * inch))
 
         # Comparison table
         if section.comparison_table:
-            story.append(Paragraph(section.comparison_table.title, self.styles["SubsectionHeading"]))
+            story.append(self._para(section.comparison_table.title, self.styles["SubsectionHeading"], mode="literal"))
             story.append(self._generate_comparison_table_element(section.comparison_table))
             story.append(Spacer(1, 0.1 * inch))
 
         # Waveforms
         if section.waveforms:
-            story.append(Paragraph("Waveforms", self.styles["SubsectionHeading"]))
+            story.append(self._para("Waveforms", self.styles["SubsectionHeading"], mode="preformatted"))
             for i, waveform in enumerate(section.waveforms):
                 # Calculate progress for this waveform
                 waveform_global_index = waveforms_processed_before + i
@@ -743,24 +761,24 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Measurements
         if section.measurements:
-            story.append(Paragraph("Measurements", self.styles["SubsectionHeading"]))
+            story.append(self._para("Measurements", self.styles["SubsectionHeading"], mode="preformatted"))
             story.append(self._generate_measurements_table(section.measurements))
             story.append(Spacer(1, 0.1 * inch))
 
         # FFT
         if section.include_fft and section.fft_frequency is not None:
-            story.append(Paragraph("FFT Analysis", self.styles["SubsectionHeading"]))
+            story.append(self._para("FFT Analysis", self.styles["SubsectionHeading"], mode="preformatted"))
             fft_img = self._generate_fft_plot(section.fft_frequency, section.fft_magnitude, section.fft_annotations)
             if fft_img:
                 fft_group = [fft_img]
                 if section.fft_caption:
-                    fft_group.append(Paragraph(self._markdown_to_reportlab(section.fft_caption), self.styles["FigureCaption"]))
+                    fft_group.append(self._para(section.fft_caption, self.styles["FigureCaption"], mode="markdown"))
                 story.append(KeepTogether(fft_group))
                 story.append(Spacer(1, 0.1 * inch))
 
         # Images
         if section.images:
-            story.append(Paragraph("Images", self.styles["SubsectionHeading"]))
+            story.append(self._para("Images", self.styles["SubsectionHeading"], mode="preformatted"))
             for img_path in section.images:
                 if Path(img_path).exists():
                     try:
@@ -772,7 +790,7 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Raw-data manifest
         if section.manifest:
-            story.append(Paragraph("Source Data Manifest", self.styles["SubsectionHeading"]))
+            story.append(self._para("Source Data Manifest", self.styles["SubsectionHeading"], mode="preformatted"))
             story.append(self._generate_manifest_table(section.manifest))
             story.append(Spacer(1, 0.1 * inch))
 
@@ -801,8 +819,8 @@ class PDFReportGenerator(BaseReportGenerator):
         keep_together_elements = []
 
         # Waveform title (e.g., "Waveform 1: CH1")
-        waveform_title = f"Waveform {index}: {waveform.label}"
-        keep_together_elements.append(Paragraph(waveform_title, self.styles["Heading4"]))
+        waveform_title = f"Waveform {index}: {self._literal_cell_text(waveform.label)}"
+        keep_together_elements.append(self._para(waveform_title, self.styles["Heading4"], mode="preformatted"))
         keep_together_elements.append(Spacer(1, 0.05 * inch))
 
         # Plot
@@ -811,7 +829,7 @@ class PDFReportGenerator(BaseReportGenerator):
             if plot_img:
                 keep_together_elements.append(plot_img)
                 if waveform.caption:
-                    keep_together_elements.append(Paragraph(self._markdown_to_reportlab(waveform.caption), self.styles["FigureCaption"]))
+                    keep_together_elements.append(self._para(waveform.caption, self.styles["FigureCaption"], mode="markdown"))
 
         # Use KeepTogether to prevent title and plot from being separated
         if keep_together_elements:
@@ -879,7 +897,7 @@ class PDFReportGenerator(BaseReportGenerator):
         story = []
 
         # Add header for regions section
-        story.append(Paragraph("Detailed Region Analysis", self.styles["Heading4"]))
+        story.append(self._para("Detailed Region Analysis", self.styles["Heading4"], mode="preformatted"))
         story.append(Spacer(1, 0.1 * inch))
 
         for i, region in enumerate(waveform.regions, 1):
@@ -909,12 +927,11 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Format region title with auto-detect indicator
         auto_indicator = " (Auto-detected)" if region.auto_detected else ""
-        region_title = f"Region {index}: {region.label}{auto_indicator}"
-        keep_elements.append(Paragraph(region_title, self.styles["Heading5"]))
+        region_title = f"Region {index}: {self._literal_cell_text(region.label)}{auto_indicator}"
+        keep_elements.append(self._para(region_title, self.styles["Heading5"], mode="preformatted"))
 
         if region.description:
-            desc_text = self._markdown_to_reportlab(region.description)
-            keep_elements.append(Paragraph(desc_text, self.styles["BodyText"]))
+            keep_elements.append(self._para(region.description, self.styles["BodyText"], mode="markdown"))
 
         keep_elements.append(Spacer(1, 0.05 * inch))
 
@@ -1011,7 +1028,7 @@ class PDFReportGenerator(BaseReportGenerator):
             else:
                 box_color = colors.HexColor("#e8f4f8")  # Light blue
 
-            recommendation_para = Paragraph(f"<b>Calibration Guidance:</b> {recommendation_text}", self.styles["BodyText"])
+            recommendation_para = self._para(f"<b>Calibration Guidance:</b> {recommendation_text}", self.styles["BodyText"], mode="preformatted")
 
             # Create a table for the colored box
             rec_table = Table([[recommendation_para]], colWidths=[5 * inch])
@@ -1033,9 +1050,8 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # AI insights (if available)
         if region.ai_insights:
-            story.append(Paragraph("<b>AI Analysis:</b>", self.styles["Heading6"]))
-            insights_text = self._markdown_to_reportlab(region.ai_insights)
-            story.append(Paragraph(insights_text, self.styles["BodyText"]))
+            story.append(self._para("<b>AI Analysis:</b>", self.styles["Heading6"], mode="preformatted"))
+            story.append(self._para(region.ai_insights, self.styles["BodyText"], mode="markdown"))
             story.append(Spacer(1, 0.1 * inch))
 
         # Separator between regions
@@ -1341,7 +1357,7 @@ class PDFReportGenerator(BaseReportGenerator):
         small_style = ParagraphStyle("ManifestSmall", parent=self.styles["Normal"], fontSize=6.5, leading=8)
 
         def _cell(text: str) -> Paragraph:
-            return Paragraph(self._literal_cell_text(text) if text else "—", small_style)
+            return self._para(text or "—", small_style, mode="literal")
 
         data = [["Run", "File", "Size", "SHA-256", "Captured", "Instrument"]]
         for entry in manifest.entries:
@@ -1377,9 +1393,9 @@ class PDFReportGenerator(BaseReportGenerator):
             title = self._markdown_to_reportlab(role.title)
             name = f" {self._markdown_to_reportlab(role.name)}" if role.name else ""
             elements.append(Spacer(1, 0.25 * inch))
-            elements.append(Paragraph(f"<b>{title}:</b>{name}", self.styles["Normal"]))
+            elements.append(self._para(f"<b>{title}:</b>{name}", self.styles["Normal"], mode="preformatted"))
             elements.append(Spacer(1, 0.05 * inch))
-            elements.append(Paragraph("Signature: ________________________&nbsp;&nbsp;&nbsp;&nbsp;Date: ____________", self.styles["Normal"]))
+            elements.append(self._para("Signature: ________________________&nbsp;&nbsp;&nbsp;&nbsp;Date: ____________", self.styles["Normal"], mode="preformatted"))
         return KeepTogether(elements)
 
     def _generate_fft_plot(self, frequency: np.ndarray, magnitude: np.ndarray, annotations=None) -> Optional[Drawing]:
@@ -1408,17 +1424,16 @@ class PDFReportGenerator(BaseReportGenerator):
         """Generate recommendations section."""
         story = []
 
-        story.append(Paragraph("Recommendations", self.styles["SectionHeading"]))
+        story.append(self._para("Recommendations", self.styles["SectionHeading"], mode="preformatted"))
 
         for i, rec in enumerate(report.recommendations, 1):
-            # Convert markdown to ReportLab XML
             rec_text = self._markdown_to_reportlab(rec)
-            story.append(Paragraph(f"{i}. {rec_text}", self.styles["Normal"]))
+            story.append(self._para(f"{i}. {rec_text}", self.styles["Normal"], mode="preformatted"))
 
         recommendations_attribution = report.recommendations_attribution()
         if recommendations_attribution:
             story.append(Spacer(1, 0.1 * inch))
-            story.append(Paragraph(f"<i>{recommendations_attribution}</i>", self.styles["Normal"]))
+            story.append(self._para(f"<i>{recommendations_attribution}</i>", self.styles["Normal"], mode="preformatted"))
 
         story.append(Spacer(1, 0.2 * inch))
 
@@ -1432,8 +1447,8 @@ class PDFReportGenerator(BaseReportGenerator):
 
         footer_text = f"Report generated on {report.metadata.test_date.strftime('%Y-%m-%d at %H:%M:%S')}"
         if report.metadata.company_name:
-            footer_text += f" by {report.metadata.company_name}"
+            footer_text += f" by {self._literal_cell_text(report.metadata.company_name)}"
 
-        story.append(Paragraph(footer_text, self.styles["Normal"]))
+        story.append(self._para(footer_text, self.styles["Normal"], mode="preformatted"))
 
         return story

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -708,10 +708,14 @@ class PDFReportGenerator(BaseReportGenerator):
         story.append(self._para(section.title, self.styles["SectionHeading"], mode="literal"))
 
         if section.content:
-            # mode="markdown" handles the \n -> <br/> conversion as part of
-            # its existing pipeline (it was previously done manually here,
-            # unescaped, before the text ever reached the Paragraph flowable).
-            story.append(self._para(section.content, self.styles["Normal"], mode="markdown"))
+            # section.content is plain user/report text, not markdown -- it
+            # must render literally (no bold/italic interpretation of
+            # underscores in identifiers like C1_rise_time, audit M34) with
+            # only \n -> <br/> conversion, same as before this branch. Escape
+            # first via _literal_cell_text, then pass through unchanged with
+            # mode="preformatted" so _para doesn't escape it a second time.
+            content_text = self._literal_cell_text(section.content).replace("\n", "<br/>")
+            story.append(self._para(content_text, self.styles["Normal"], mode="preformatted"))
             story.append(Spacer(1, 0.1 * inch))
 
         # AI insights

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -360,7 +360,7 @@ class PDFReportGenerator(BaseReportGenerator):
         code_blocks = {}
 
         def save_code(match):
-            key = f"__CODE_{len(code_blocks)}__"
+            key = f"\x00CODE{len(code_blocks)}\x00"
             code_blocks[key] = match.group(1)
             return key
 

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -325,13 +325,17 @@ class MainWindow(QMainWindow):
                 for waveform in waveforms:
                     self.waveform_list.addItem(f"{waveform.label} - {Path(file_path).name}")
 
+                # New waveforms mean any prior AI analysis no longer
+                # corresponds to the loaded data (audit H27). Clear as soon
+                # as self.waveforms has actually changed, inside the loop,
+                # so a later file in the batch failing to load (or
+                # load_annotations_into raising) still leaves stale AI
+                # content invalidated rather than surviving the exception.
+                self.ai_analysis_panel._clear_results()
+
             applied = load_annotations_into(self.waveforms)
             if applied:
                 logger.info(f"Applied {applied} saved annotation(s) from sidecar files")
-
-            # New waveforms mean any prior AI analysis no longer corresponds
-            # to the loaded data (audit H27).
-            self.ai_analysis_panel._clear_results()
 
             self.statusBar().showMessage(f"Imported {len(file_paths)} waveform file(s)")
 

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -329,6 +329,10 @@ class MainWindow(QMainWindow):
             if applied:
                 logger.info(f"Applied {applied} saved annotation(s) from sidecar files")
 
+            # New waveforms mean any prior AI analysis no longer corresponds
+            # to the loaded data (audit H27).
+            self.ai_analysis_panel._clear_results()
+
             self.statusBar().showMessage(f"Imported {len(file_paths)} waveform file(s)")
 
         except Exception as e:
@@ -371,6 +375,9 @@ class MainWindow(QMainWindow):
         if reply == QMessageBox.StandardButton.Yes:
             self.waveforms.clear()
             self.waveform_list.clear()
+            # Any AI-generated content described the data that just left --
+            # it no longer corresponds to anything (audit H27).
+            self.ai_analysis_panel._clear_results()
             self.statusBar().showMessage("Data cleared")
 
     def _configure_llm(self):

--- a/tests/test_main_window_ai_staleness.py
+++ b/tests/test_main_window_ai_staleness.py
@@ -90,3 +90,33 @@ def test_import_waveforms_invalidates_ai_content(window, monkeypatch):
     window._import_waveforms()
 
     assert not window.ai_analysis_panel.has_generated_content()
+
+
+def test_import_waveforms_partial_failure_still_invalidates_ai_content(window, monkeypatch):
+    """Regression for the whole-branch review finding (H27 partial-import
+    case): if WaveformLoader.load raises partway through a multi-file
+    import, self.waveforms already changed from the files loaded before
+    the failure, so stale AI content must still be invalidated even though
+    the overall _import_waveforms() call ends up reporting an error."""
+    _seed_ai_content(window)
+
+    file1 = Path("capture1.csv")
+    file2 = Path("corrupt2.csv")
+    monkeypatch.setattr(
+        QFileDialog,
+        "getOpenFileNames",
+        staticmethod(lambda *a, **k: ([str(file1), str(file2)], "")),
+    )
+
+    def _load(p):
+        if str(p) == str(file1):
+            return [_make_waveform("C1", file1)]
+        raise ValueError("corrupt waveform file")
+
+    monkeypatch.setattr(WaveformLoader, "load", staticmethod(_load))
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
+
+    window._import_waveforms()
+
+    assert len(window.waveforms) == 1  # file1's waveform was kept
+    assert not window.ai_analysis_panel.has_generated_content()

--- a/tests/test_main_window_ai_staleness.py
+++ b/tests/test_main_window_ai_staleness.py
@@ -1,0 +1,92 @@
+"""AIAnalysisPanel.generated_content persisted across _new_report() /
+waveform re-import, so a report built from new data could silently ship AI
+summary/findings that describe the previous dataset (AUDIT.md H27).
+
+Constructing MainWindow needs PyQt6 and a display; QT_QPA_PLATFORM=offscreen
+supplies the latter. Guarded by importorskip so CI (no PyQt6 in the
+dev/web extras) skips these tests instead of failing -- same pattern as
+tests/test_main_window_annotations.py.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt6")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication, QFileDialog, QMessageBox  # noqa: E402
+
+from scpi_control.report_generator import main_window as mw_module  # noqa: E402
+from scpi_control.report_generator.models.app_settings import AppSettings  # noqa: E402
+from scpi_control.report_generator.models.report_data import WaveformData  # noqa: E402
+from scpi_control.report_generator.utils.waveform_loader import WaveformLoader  # noqa: E402
+
+_qapp = None  # module-level: see tests/test_main_window_annotations.py for why
+# this must survive as a live reference.
+
+
+def _make_waveform(channel: str, source_file: Path) -> WaveformData:
+    t = np.linspace(0, 1e-4, 200)
+    voltage = np.sin(2 * np.pi * 20_000 * t)
+    return WaveformData(
+        channel=channel,
+        time=t,
+        voltage=voltage,
+        sample_rate=5e6,
+        record_length=200,
+        source_file=source_file,
+    )
+
+
+@pytest.fixture
+def window(monkeypatch):
+    monkeypatch.setattr(AppSettings, "load", classmethod(lambda cls: AppSettings()))
+
+    global _qapp
+    _qapp = QApplication.instance() or QApplication([])
+    win = mw_module.MainWindow()
+    yield win
+    win.close()
+
+
+def _seed_ai_content(window):
+    window.ai_analysis_panel.generated_content = {
+        "executive_summary": "1 kHz square wave, Vpp 3.3 V",
+        "key_findings": ["Rise time within spec"],
+        "recommendations": [],
+    }
+    assert window.ai_analysis_panel.has_generated_content()
+
+
+def test_clear_data_invalidates_ai_content(window, monkeypatch):
+    window.waveforms.append(_make_waveform("C1", Path("capture.csv")))
+    _seed_ai_content(window)
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes)
+
+    window._clear_data()
+
+    assert not window.ai_analysis_panel.has_generated_content()
+
+
+def test_import_waveforms_invalidates_ai_content(window, monkeypatch):
+    _seed_ai_content(window)
+
+    file1 = Path("capture1.csv")
+    monkeypatch.setattr(
+        QFileDialog,
+        "getOpenFileNames",
+        staticmethod(lambda *a, **k: ([str(file1)], "")),
+    )
+    monkeypatch.setattr(
+        WaveformLoader,
+        "load",
+        staticmethod(lambda p: [_make_waveform("C1", file1)]),
+    )
+
+    window._import_waveforms()
+
+    assert not window.ai_analysis_panel.has_generated_content()

--- a/tests/test_markdown_generator_plot_filenames.py
+++ b/tests/test_markdown_generator_plot_filenames.py
@@ -1,0 +1,80 @@
+"""Plot filenames are built directly from report text (section titles,
+channel labels) -- AUDIT.md H24. An unsanitized name can escape
+plots_path (path traversal), crash on '/', or collide with NTFS
+alternate-data-stream syntax on ':'.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import (
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+@pytest.mark.parametrize(
+    "name,forbidden_char",
+    [
+        ("a/b", "/"),
+        ("name:stream", ":"),
+    ],
+)
+def test_sanitize_plot_name_allowlists_unsafe_characters(name, forbidden_char):
+    sanitized = MarkdownReportGenerator()._sanitize_plot_name(name)
+    assert sanitized != ""
+    assert forbidden_char not in sanitized
+
+
+def test_sanitize_plot_name_never_returns_empty():
+    assert MarkdownReportGenerator()._sanitize_plot_name("") == "plot"
+
+
+def test_sanitize_plot_name_cannot_produce_a_path_separator_from_traversal_text():
+    """'..' survives as characters -- harmless on its own, since with no '/'
+    there is no path component boundary for it to act as a parent-directory
+    reference across. The sanitizer's actual job is making sure '..' can
+    never be RECOMBINED with a separator it introduces."""
+    sanitized = MarkdownReportGenerator()._sanitize_plot_name("../../../evil")
+    assert "/" not in sanitized
+    assert "\\" not in sanitized
+
+
+def test_sanitize_plot_name_is_stable_for_an_ordinary_title():
+    gen = MarkdownReportGenerator()
+    assert gen._sanitize_plot_name("Test 1: Rise Time") == "Test_1__Rise_Time"
+
+
+def _make_report_with_section_title(title: str) -> TestReport:
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        sample_rate=1e6,
+        record_length=100,
+    )
+    section = TestSection(title=title, content="Measured on C1.", waveforms=[waveform])
+    metadata = ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16))
+    return TestReport(metadata=metadata, sections=[section])
+
+
+def test_a_path_traversal_section_title_cannot_escape_plots_path(tmp_path):
+    """End-to-end: drive generate() with an adversarial section title and
+    confirm the plot file lands under plots_path, not somewhere it escaped to."""
+    out = tmp_path / "r.md"
+    report = _make_report_with_section_title("../../../evil")
+
+    assert MarkdownReportGenerator().generate(report, out) is True
+
+    plots_path = out.parent / "plots"
+    written = list(plots_path.glob("*.png"))
+    assert len(written) == 1
+    assert written[0].resolve().is_relative_to(plots_path.resolve())
+    # No file was written outside plots_path.
+    assert not (tmp_path.parent / "evil.png").exists()

--- a/tests/test_pdf_generator_escaping.py
+++ b/tests/test_pdf_generator_escaping.py
@@ -1,0 +1,88 @@
+"""ReportLab's Paragraph() parses its text argument as XML mini-markup.
+~40 call sites in pdf_generator.py pass report/metadata text to it; before
+this fix, most were unescaped -- a channel label or comparison-run title
+containing '<', '>' or '&' could corrupt the parse or silently truncate
+content (AUDIT.md H25).
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("reportlab")
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+from scpi_control.report_generator.models.report_data import (  # noqa: E402
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def make_report(**metadata_overrides):
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        sample_rate=1e6,
+        record_length=100,
+    )
+    section = TestSection(title="Rise Time", content="Measured on C1.", waveforms=[waveform])
+    metadata_kwargs = dict(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16))
+    metadata_kwargs.update(metadata_overrides)
+    metadata = ReportMetadata(**metadata_kwargs)
+    return TestReport(metadata=metadata, sections=[section])
+
+
+def test_para_markdown_mode_escapes_xml_specials():
+    gen = PDFReportGenerator()
+    para = gen._para("A & B < C > D", gen.styles["Normal"], mode="markdown")
+    assert "&amp;" in para.text
+    assert "&lt;" in para.text
+    assert "&gt;" in para.text
+    assert "<" not in para.text.replace("&lt;", "")
+
+
+def test_para_literal_mode_escapes_and_does_not_interpret_markdown():
+    gen = PDFReportGenerator()
+    para = gen._para("**bold** & <tag>", gen.styles["Normal"], mode="literal")
+    assert "<b>" not in para.text  # literal mode does not apply markdown
+    assert "&amp;" in para.text
+    assert "&lt;tag&gt;" in para.text
+
+
+def test_para_preformatted_mode_passes_through_unchanged():
+    gen = PDFReportGenerator()
+    para = gen._para("<b>already escaped</b>", gen.styles["Normal"], mode="preformatted")
+    assert para.text == "<b>already escaped</b>"
+
+
+def test_unescaped_company_name_reaches_paragraph_escaped(tmp_path):
+    """Regression for the specific H25 sites the audit named: company_name
+    and title previously reached Paragraph() with no escaping at all."""
+    out = tmp_path / "r.pdf"
+    report = make_report(company_name="A & B Labs", title="Report <1>")
+    assert PDFReportGenerator().generate(report, out) is True
+    assert out.stat().st_size > 0
+
+
+def test_section_title_with_xml_specials_does_not_crash_generation(tmp_path):
+    out = tmp_path / "r.pdf"
+    report = make_report()
+    report.sections[0].title = "Overshoot <CH2> & Ringing"
+    assert PDFReportGenerator().generate(report, out) is True
+
+
+def test_paragraph_construction_only_happens_through__para():
+    """Structural regression guard: a new call site that constructs
+    Paragraph(...) directly (bypassing _para) reintroduces H25 by
+    forgetting to escape. Exactly one occurrence of the literal substring
+    is expected -- the `return Paragraph(escaped, style)` inside _para
+    itself."""
+    src = Path("scpi_control/report_generator/generators/pdf_generator.py").read_text(encoding="utf-8")
+    count = src.count("Paragraph(")
+    assert count == 1, f"expected exactly 1 direct Paragraph(...) call (inside _para), found {count}"

--- a/tests/test_pdf_generator_escaping.py
+++ b/tests/test_pdf_generator_escaping.py
@@ -77,6 +77,45 @@ def test_section_title_with_xml_specials_does_not_crash_generation(tmp_path):
     assert PDFReportGenerator().generate(report, out) is True
 
 
+def test_section_content_does_not_interpret_markdown():
+    """Regression for the whole-branch review finding (H26): section.content
+    is plain report/user text, not markdown. Before this fix it was routed
+    through mode="markdown", which italicised underscore-delimited text --
+    reintroducing the identifier-mangling defect (audit M34) where
+    C1_rise_time would render as C1<i>rise</i>time -- and downgraded
+    cp1252 symbols like deg that used to render fine as a literal degree
+    sign."""
+    gen = PDFReportGenerator()
+    section = TestSection(
+        title="Rise Time",
+        content="Measured C1_rise_time at 45°C\nsecond line",
+        waveforms=[],
+    )
+    story = gen._generate_section(section)
+    content_para = story[1]
+
+    assert "<i>" not in content_para.text
+    assert "<b>" not in content_para.text
+    assert "C1_rise_time" in content_para.text
+    assert "°" in content_para.text  # degree sign survives verbatim
+    assert " deg" not in content_para.text
+    assert "<br/>" in content_para.text  # \n -> <br/> conversion still happens
+
+
+def test_section_content_still_escapes_xml_specials():
+    """section.content must still be escaped for reportlab's mini-XML
+    (the H25 fix this whole branch exists for) even though it's no longer
+    routed through the markdown pipeline."""
+    gen = PDFReportGenerator()
+    section = TestSection(title="T", content="A & B < C > D", waveforms=[])
+    story = gen._generate_section(section)
+    content_para = story[1]
+
+    assert "&amp;" in content_para.text
+    assert "&lt;" in content_para.text
+    assert "&gt;" in content_para.text
+
+
 def test_paragraph_construction_only_happens_through__para():
     """Structural regression guard: a new call site that constructs
     Paragraph(...) directly (bypassing _para) reintroduces H25 by

--- a/tests/test_pdf_unicode_safety.py
+++ b/tests/test_pdf_unicode_safety.py
@@ -26,3 +26,16 @@ def test_markdown_to_reportlab_output_is_winansi_safe():
 
     # And the known symbols are mapped to readable text, not silently dropped.
     assert "!" in out  # warning sign -> "!"
+
+
+def test_code_span_survives_alongside_bold_markdown():
+    """AUDIT.md H26: save_code() placeholders were __CODE_n__, and the bold
+    regex re.sub(r"__(.+?)__", ...) matched that placeholder itself (both are
+    double-underscore-delimited), corrupting or losing the code span."""
+    gen = PDFReportGenerator()
+    out = gen._markdown_to_reportlab("Vpp measured `1.2 V` vs limit `1.0 V`, **exceeds spec**")
+
+    assert '<font face="Courier">1.2 V</font>' in out
+    assert '<font face="Courier">1.0 V</font>' in out
+    assert "<b>exceeds spec</b>" in out
+    assert "CODE" not in out  # no leaked placeholder text


### PR DESCRIPTION
## Summary

Closes AUDIT.md theme #4 ("report escaping", findings H24-H27) — the last of the whole-project audit's four defect themes:

- **H24** — plot filenames built from report text (section titles, channel labels) are now allowlist-sanitized, with a path-containment backstop, in `markdown_generator.py` (fixes path traversal, `/` crashes, and NTFS alternate-data-stream collisions on `:`)
- **H25** — ~40 ReportLab `Paragraph()` construction sites in `pdf_generator.py`, roughly half previously unescaped, now all route through one new `_para()` method — the only remaining path to `Paragraph()` construction in the file, so a future call site can't reintroduce the bug
- **H26** — a code-span placeholder (`__CODE_n__`) inside `_markdown_to_reportlab` collided with the bold-markdown regex it ran through afterward, corrupting or crashing generation on ordinary LLM output; changed to a null-byte-delimited format
- **H27** — `AIAnalysisPanel.generated_content` (AI-written summary/findings) now gets invalidated whenever the underlying waveform data changes, instead of silently shipping stale narrative text into a report built from different data (including on a partial multi-file import failure, caught by the final whole-branch review)

The final whole-branch review caught one real regression the per-task reviews missed: the H25 fix for `section.content` initially changed *rendering*, not just escaping (markdown interpretation of underscore-bearing identifiers like `C1_rise_time`, plus symbol downgrades like `°`→` deg`) — fixed on the branch before merge.

**Not fully closed** — theme #4 has a queued follow-up: `markdown_generator.py` still interpolates report text raw into Markdown syntax (a `|` in a measurement name breaks a table, a `]` in a waveform label breaks an image link). This branch fixed Markdown filenames and PDF text; the Markdown text path has the same defect class, scoped out of this branch's spec. Logged as a follow-up for the next sub-project.

## Test plan

- [x] `pytest -m "not slow" -n 8` — 2875 passed, 19 skipped
- [x] Full `pytest` (no marker filter) — 2908 passed, 19 skipped, 0 failed
- [x] `CHANGELOG.md` / `docs/about/changelog.md` mirror verified byte-identical
- [x] 5 tasks each independently reviewed (spec ✅, quality Approved, 0 Critical/Important) + a final whole-branch review (1 Important + 1 Minor found and fixed, verified in a scoped re-review)
- [ ] Reviewed on the branch page
