### PR TITLE
fix(report): escape free text in the Markdown table/link paths (theme #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parses its input as XML mini-markup — a `<`, `>` or `&` in any of them
   could corrupt the page or silently drop content. Every text construction
   in the PDF generator now routes through one escaping helper.
+- **Markdown report text reached table cells and link/alt text unescaped.**
+  Technician/equipment metadata, measurement names and units, comparison-table
+  cells, and manifest entries were interpolated raw into `| ... |` table rows,
+  where an unescaped `|` truncated the cell and corrupted the row; waveform,
+  region, and overlay labels were interpolated raw into `![...]` alt text,
+  where an unescaped `]` closed the link early and corrupted everything after
+  it. Both are now escaped through dedicated helpers before reaching Markdown
+  syntax (the Markdown-text sibling of the PDF escaping fix above). Also
+  fixed in the Markdown generator: a section title equal to a Windows
+  reserved device name (`NUL`, `CON`, `COM1`, ...) could produce a plot
+  filename that Windows treats as a reference to the device itself regardless
+  of the `.png` extension, and two overlay plots in the same section whose
+  channel labels collapsed to the same sanitized filename (e.g. `A/B` and
+  `A:B`) could silently overwrite each other's PNG — the overlay filename now
+  includes a disambiguating index, matching the existing waveform/region plot
+  pattern.
 
 ### Changed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -58,6 +58,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parses its input as XML mini-markup — a `<`, `>` or `&` in any of them
   could corrupt the page or silently drop content. Every text construction
   in the PDF generator now routes through one escaping helper.
+- **Markdown report text reached table cells and link/alt text unescaped.**
+  Technician/equipment metadata, measurement names and units, comparison-table
+  cells, and manifest entries were interpolated raw into `| ... |` table rows,
+  where an unescaped `|` truncated the cell and corrupted the row; waveform,
+  region, and overlay labels were interpolated raw into `![...]` alt text,
+  where an unescaped `]` closed the link early and corrupted everything after
+  it. Both are now escaped through dedicated helpers before reaching Markdown
+  syntax (the Markdown-text sibling of the PDF escaping fix above). Also
+  fixed in the Markdown generator: a section title equal to a Windows
+  reserved device name (`NUL`, `CON`, `COM1`, ...) could produce a plot
+  filename that Windows treats as a reference to the device itself regardless
+  of the `.png` extension, and two overlay plots in the same section whose
+  channel labels collapsed to the same sanitized filename (e.g. `A/B` and
+  `A:B`) could silently overwrite each other's PNG — the overlay filename now
+  includes a disambiguating index, matching the existing waveform/region plot
+  pattern.
 
 ### Changed
 

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -151,32 +151,56 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
         return "\n".join(lines)
 
+    _TABLE_CELL_ESCAPE = str.maketrans({"\\": "\\\\", "|": "\\|"})
+
+    def _escape_table_cell(self, text) -> str:
+        """Escape a value for use inside a `| ... |` Markdown table cell.
+
+        Report text (measurement names, technician/equipment metadata, criteria
+        labels, manifest entries, comparison-table cells) reaches table rows
+        directly; an unescaped '|' truncates the cell and corrupts the row
+        (AUDIT.md theme #4 follow-up -- the Markdown-text sibling of H25).
+        """
+        return str(text).translate(self._TABLE_CELL_ESCAPE)
+
+    _LINK_TEXT_ESCAPE = str.maketrans({"\\": "\\\\", "[": "\\[", "]": "\\]"})
+
+    def _escape_link_text(self, text) -> str:
+        """Escape a value for use as Markdown `[...]`/`![...]` link/alt text.
+
+        An unescaped ']' in report text (a waveform/region label, a channel
+        label) closes the link early and corrupts everything after it in the
+        rendered document (AUDIT.md theme #4 follow-up).
+        """
+        return str(text).translate(self._LINK_TEXT_ESCAPE)
+
     def _generate_metadata_section(self, report: TestReport) -> str:
         """Generate metadata table."""
         lines = []
         meta = report.metadata
+        esc = self._escape_table_cell
 
         lines.append("| Field | Value |")
         lines.append("|-------|-------|")
-        lines.append(f"| **Technician** | {meta.technician} |")
+        lines.append(f"| **Technician** | {esc(meta.technician)} |")
         lines.append(f"| **Date** | {meta.test_date.strftime('%Y-%m-%d %H:%M:%S')} |")
 
         if meta.equipment_model:
-            lines.append(f"| **Equipment** | {meta.equipment_model} |")
+            lines.append(f"| **Equipment** | {esc(meta.equipment_model)} |")
         if meta.equipment_id:
-            lines.append(f"| **Equipment ID** | {meta.equipment_id} |")
+            lines.append(f"| **Equipment ID** | {esc(meta.equipment_id)} |")
         if meta.test_procedure:
-            lines.append(f"| **Test Procedure** | {meta.test_procedure} |")
+            lines.append(f"| **Test Procedure** | {esc(meta.test_procedure)} |")
         if meta.project_name:
-            lines.append(f"| **Project** | {meta.project_name} |")
+            lines.append(f"| **Project** | {esc(meta.project_name)} |")
         if meta.customer:
-            lines.append(f"| **Customer** | {meta.customer} |")
+            lines.append(f"| **Customer** | {esc(meta.customer)} |")
         if meta.temperature:
-            lines.append(f"| **Temperature** | {meta.temperature} |")
+            lines.append(f"| **Temperature** | {esc(meta.temperature)} |")
         if meta.humidity:
-            lines.append(f"| **Humidity** | {meta.humidity} |")
+            lines.append(f"| **Humidity** | {esc(meta.humidity)} |")
         if meta.location:
-            lines.append(f"| **Location** | {meta.location} |")
+            lines.append(f"| **Location** | {esc(meta.location)} |")
 
         return "\n".join(lines)
 
@@ -206,10 +230,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
         # Overlay plots (comparison/batch)
         if section.overlay_plots and self.include_plots:
-            for spec in section.overlay_plots:
-                plot_path = self._generate_overlay_plot(spec, base_path, f"{section.title}_overlay_{spec.channel_label}")
+            for i, spec in enumerate(section.overlay_plots):
+                plot_path = self._generate_overlay_plot(spec, base_path, f"{section.title}_overlay_{i}_{spec.channel_label}")
                 if plot_path:
-                    lines.append(f"![Overlay: {spec.channel_label}]({plot_path})")
+                    lines.append(f"![Overlay: {self._escape_link_text(spec.channel_label)}]({plot_path})")
                     if spec.caption:
                         lines.append("")
                         lines.append(f"*{spec.caption}*")
@@ -277,7 +301,7 @@ class MarkdownReportGenerator(BaseReportGenerator):
         # Generate plot if requested
         if self.include_plots:
             plot_path = self._generate_waveform_plot(waveform, base_path, name)
-            lines.append(f"![{waveform.label}]({plot_path})")
+            lines.append(f"![{self._escape_link_text(waveform.label)}]({plot_path})")
             if waveform.caption:
                 lines.append("")
                 lines.append(f"*{waveform.caption}*")
@@ -387,7 +411,7 @@ class MarkdownReportGenerator(BaseReportGenerator):
         if self.include_plots:
             plot_path = self._generate_region_plot(waveform, region, base_path, name)
             if plot_path:
-                lines.append(f"![{region.label} - Zoomed View]({plot_path})")
+                lines.append(f"![{self._escape_link_text(region.label)} - Zoomed View]({plot_path})")
                 lines.append("")
 
         # Region analysis table
@@ -445,6 +469,10 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
     _FILENAME_SAFE = re.compile(r"[^A-Za-z0-9._-]")
 
+    # Windows reserved device names -- reserved for the filename segment
+    # before the FIRST '.', regardless of any extension appended after it.
+    _RESERVED_DEVICE_NAMES = frozenset({"CON", "PRN", "AUX", "NUL"} | {f"COM{d}" for d in range(1, 10)} | {f"LPT{d}" for d in range(1, 10)})
+
     def _sanitize_plot_name(self, name: str) -> str:
         """Allowlist a report-text-derived string for use in a filename.
 
@@ -453,9 +481,19 @@ class MarkdownReportGenerator(BaseReportGenerator):
         without sanitizing it a title like '../../etc/x' can escape
         plots_path, '/' crashes the write, and ':' collides with NTFS
         alternate-data-stream syntax (AUDIT.md H24).
+
+        A section title like 'NUL' or 'con' survives the allowlist above
+        unchanged and produces a filename ('NUL.png') that Windows treats as
+        a reference to the actual reserved device, regardless of extension
+        -- so the segment before the first '.' is checked against the
+        Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+        and disambiguated if it matches (AUDIT.md theme #4 follow-up).
         """
-        sanitized = self._FILENAME_SAFE.sub("_", name)
-        return sanitized or "plot"
+        sanitized = self._FILENAME_SAFE.sub("_", name) or "plot"
+        first_segment, sep, rest = sanitized.partition(".")
+        if first_segment.upper() in self._RESERVED_DEVICE_NAMES:
+            sanitized = f"{first_segment}_plot{sep}{rest}"
+        return sanitized
 
     def _generate_region_plot(self, waveform: WaveformData, region, base_path: Path, name: str) -> Optional[str]:
         """
@@ -536,11 +574,11 @@ class MarkdownReportGenerator(BaseReportGenerator):
         lines.append("|-------------|-------|--------|----------|")
 
         for meas in measurements:
-            name = meas.name
+            name = self._escape_table_cell(meas.name)
             if meas.channel:
-                name += f" ({meas.channel})"
+                name += f" ({self._escape_table_cell(meas.channel)})"
 
-            value = meas.format_value()
+            value = self._escape_table_cell(meas.format_value())
 
             status = meas.get_status_symbol()
             if meas.passed is True:
@@ -550,11 +588,12 @@ class MarkdownReportGenerator(BaseReportGenerator):
             else:
                 status = "—"
 
+            unit = self._escape_table_cell(meas.unit)
             criteria = []
             if meas.criteria_min is not None:
-                criteria.append(f"min: {meas.criteria_min:.6g} {meas.unit}")
+                criteria.append(f"min: {meas.criteria_min:.6g} {unit}")
             if meas.criteria_max is not None:
-                criteria.append(f"max: {meas.criteria_max:.6g} {meas.unit}")
+                criteria.append(f"max: {meas.criteria_max:.6g} {unit}")
             criteria_str = "<br>".join(criteria) if criteria else "—"
 
             lines.append(f"| {name} | {value} | {status} | {criteria_str} |")
@@ -633,12 +672,12 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
     def _generate_comparison_table(self, table) -> str:
         lines = [f"### {table.title}", ""]
-        lines.append("| " + " | ".join(table.headers) + " |")
+        lines.append("| " + " | ".join(self._escape_table_cell(h) for h in table.headers) + " |")
         lines.append("|" + "|".join("---" for _ in table.headers) + "|")
         for row in table.rows:
             cells = []
             for cell in row:
-                text = cell.text
+                text = self._escape_table_cell(cell.text)
                 if cell.status == "pass":
                     text += " ✅"
                 elif cell.status == "fail":
@@ -654,7 +693,11 @@ class MarkdownReportGenerator(BaseReportGenerator):
         lines.append("| Run | File | Size (bytes) | SHA-256 | Captured | Instrument |")
         lines.append("|---|---|---|---|---|---|")
         for entry in manifest.entries:
-            lines.append(f"| {entry.run_label} | {entry.file_path} | {entry.size_bytes} | `{entry.sha256}` | {entry.capture_timestamp or 'unknown'} | {entry.instrument or '—'} |")
+            run_label = self._escape_table_cell(entry.run_label)
+            file_path = self._escape_table_cell(entry.file_path)
+            captured = self._escape_table_cell(entry.capture_timestamp) if entry.capture_timestamp else "unknown"
+            instrument = self._escape_table_cell(entry.instrument) if entry.instrument else "—"
+            lines.append(f"| {run_label} | {file_path} | {entry.size_bytes} | `{entry.sha256}` | {captured} | {instrument} |")
         return "\n".join(lines)
 
     def _generate_signoff(self, signoff) -> str:

--- a/tests/test_markdown_generator_escaping.py
+++ b/tests/test_markdown_generator_escaping.py
@@ -1,0 +1,291 @@
+"""Free text in report data (technician/equipment metadata, measurement
+names/units, comparison-table cells, manifest entries, waveform/region/
+overlay labels) is interpolated raw into Markdown table and link/alt-text
+syntax. An unescaped '|' truncates a table cell early and corrupts the row;
+an unescaped ']' in link/alt text closes the link early and corrupts
+everything after it in the rendered document (AUDIT.md theme #4 follow-up --
+the Markdown-text sibling of H25).
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import (
+    MeasurementResult,
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+from scpi_control.report_generator.models.report_elements import (
+    ComparisonTable,
+    DataManifest,
+    ManifestEntry,
+    OverlayPlotSpec,
+    OverlayTrace,
+    TableCell,
+)
+
+
+def _report(section, metadata=None):
+    metadata = metadata or ReportMetadata(title="T", technician="R", test_date=datetime(2026, 8, 21))
+    return TestReport(metadata=metadata, sections=[section])
+
+
+def _generate(tmp_path, report, include_plots=False):
+    out = tmp_path / "report.md"
+    assert MarkdownReportGenerator(include_plots=include_plots).generate(report, out)
+    return out.read_text(encoding="utf-8")
+
+
+def _make_waveform(**overrides):
+    t = np.arange(100) / 1e6
+    kwargs = dict(
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        sample_rate=1e6,
+        record_length=100,
+    )
+    kwargs.update(overrides)
+    return WaveformData(**kwargs)
+
+
+# --- Escaping helpers, in isolation -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a|b", "a\\|b"),
+        ("a\\b", "a\\\\b"),
+        ("a\\|b", "a\\\\\\|b"),
+        ("plain text", "plain text"),
+    ],
+)
+def test_escape_table_cell(raw, expected):
+    assert MarkdownReportGenerator()._escape_table_cell(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a]b", "a\\]b"),
+        ("a[b", "a\\[b"),
+        ("a[b]c", "a\\[b\\]c"),
+        ("a\\b", "a\\\\b"),
+        ("plain text", "plain text"),
+    ],
+)
+def test_escape_link_text(raw, expected):
+    assert MarkdownReportGenerator()._escape_link_text(raw) == expected
+
+
+# --- Defect 1: table-cell escaping -------------------------------------
+
+
+def test_metadata_table_escapes_free_text_fields(tmp_path):
+    """A '|' in any free-text metadata field must not truncate its table
+    cell and corrupt the row (AUDIT.md theme #4 follow-up)."""
+    metadata = ReportMetadata(
+        title="Bench Check",
+        technician="Robin | Evil",
+        test_date=datetime(2026, 8, 21),
+        equipment_model="Model | X",
+        equipment_id="ID | 1",
+        test_procedure="Proc | A",
+        project_name="Proj | B",
+        customer="Cust | C",
+        temperature="20 | C",
+        humidity="50 | %",
+        location="Lab | 1",
+    )
+    section = TestSection(title="S")
+    text = _generate(tmp_path, _report(section, metadata))
+
+    assert "| **Technician** | Robin \\| Evil |" in text
+    assert "| **Equipment** | Model \\| X |" in text
+    assert "| **Equipment ID** | ID \\| 1 |" in text
+    assert "| **Test Procedure** | Proc \\| A |" in text
+    assert "| **Project** | Proj \\| B |" in text
+    assert "| **Customer** | Cust \\| C |" in text
+    assert "| **Temperature** | 20 \\| C |" in text
+    assert "| **Humidity** | 50 \\| % |" in text
+    assert "| **Location** | Lab \\| 1 |" in text
+
+
+def test_measurements_table_escapes_name_channel_unit_and_value(tmp_path):
+    """meas.name, meas.channel, meas.unit, and format_value() (which embeds
+    the unit) are all free text and must be escaped before landing in the
+    measurements table."""
+    meas = MeasurementResult(
+        name="Vpp | evil",
+        value=1.234,
+        unit="V | evil",
+        channel="C1 | evil",
+        criteria_min=1.0,
+        criteria_max=2.0,
+    )
+    section = TestSection(title="S", measurements=[meas])
+    text = _generate(tmp_path, _report(section))
+
+    assert "Vpp \\| evil (C1 \\| evil)" in text
+    assert "1.234 V \\| evil" in text
+    assert "min: 1 V \\| evil" in text
+    assert "max: 2 V \\| evil" in text
+    # No line should contain the raw, unescaped free text -- an unescaped
+    # '|' would corrupt the row.
+    assert "Vpp | evil" not in text
+    assert "C1 | evil" not in text
+
+
+def test_comparison_table_escapes_headers_and_cell_text(tmp_path):
+    table = ComparisonTable(
+        title="Cmp",
+        headers=["Measurement", "before | after"],
+        rows=[[TableCell("vpp"), TableCell("2.0 | evil")]],
+    )
+    section = TestSection(title="S")
+    section.comparison_table = table
+    text = _generate(tmp_path, _report(section))
+
+    assert "| Measurement | before \\| after |" in text
+    assert "| vpp | 2.0 \\| evil |" in text
+
+
+def test_manifest_escapes_free_text_fields_but_not_sha256(tmp_path):
+    """run_label, file_path, instrument, and capture_timestamp are free
+    text; sha256 is a computed hex digest already inside a code span and
+    must be left untouched."""
+    full_hash = "ab" * 32
+    entry = ManifestEntry(
+        run_label="run | evil",
+        file_path="a | evil.csv",
+        size_bytes=10,
+        sha256=full_hash,
+        capture_timestamp="2026 | evil",
+        instrument="Scope | evil",
+    )
+    section = TestSection(title="S")
+    section.manifest = DataManifest(entries=[entry])
+    text = _generate(tmp_path, _report(section))
+
+    expected_row = f"| run \\| evil | a \\| evil.csv | 10 | `{full_hash}` | 2026 \\| evil | Scope \\| evil |"
+    assert expected_row in text
+
+
+# --- Defect 2: link/alt-text escaping -----------------------------------
+
+
+def test_waveform_alt_text_escapes_label(tmp_path):
+    """An unescaped ']' in waveform.label would close the '![...]' alt
+    text early and corrupt the rest of the rendered line."""
+    waveform = _make_waveform(label="Trace ] evil")
+    section = TestSection(title="S", waveforms=[waveform])
+    text = _generate(tmp_path, _report(section), include_plots=True)
+
+    assert "![Trace \\] evil](plots/" in text
+    assert "![Trace ] evil](plots/" not in text
+
+
+def test_region_alt_text_escapes_label(tmp_path):
+    waveform = _make_waveform()
+    waveform.add_region(start_time=0.0, end_time=50e-6, label="Region ] evil")
+    section = TestSection(title="S", waveforms=[waveform])
+    text = _generate(tmp_path, _report(section), include_plots=True)
+
+    assert "![Region \\] evil - Zoomed View](plots/" in text
+    assert "![Region ] evil - Zoomed View](plots/" not in text
+
+
+def test_overlay_alt_text_escapes_channel_label(tmp_path):
+    waveform = _make_waveform()
+    section = TestSection(title="S")
+    section.overlay_plots = [
+        OverlayPlotSpec(channel_label="1 ] evil", traces=[OverlayTrace("before", waveform, "#1f77b4")])
+    ]
+    text = _generate(tmp_path, _report(section), include_plots=True)
+
+    assert "![Overlay: 1 \\] evil](plots/" in text
+    assert "![Overlay: 1 ] evil](plots/" not in text
+
+
+# --- Defect 3: Windows reserved device names ----------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "NUL",
+        "nul",
+        "CON",
+        "con",
+        "PRN",
+        "AUX",
+        "COM1",
+        "com9",
+        "LPT1",
+        "lpt9",
+    ],
+)
+def test_sanitize_plot_name_avoids_reserved_device_names(name):
+    """A bare reserved device name (case-insensitive) must not survive
+    sanitization -- 'NUL.png' refers to the NUL device on Windows
+    regardless of the .png extension the caller appends."""
+    sanitized = MarkdownReportGenerator()._sanitize_plot_name(name)
+    assert sanitized.split(".", 1)[0].upper() not in MarkdownReportGenerator._RESERVED_DEVICE_NAMES
+
+
+def test_sanitize_plot_name_avoids_reserved_device_name_with_suffix():
+    """A reserved name followed by a dot-suffix ('NUL.something') is still
+    reserved for the segment before the first dot -- appending the caller's
+    .png afterwards would still land on 'NUL....png'."""
+    sanitized = MarkdownReportGenerator()._sanitize_plot_name("NUL.something")
+    assert sanitized.split(".", 1)[0].upper() not in MarkdownReportGenerator._RESERVED_DEVICE_NAMES
+
+
+@pytest.mark.parametrize("name", ["COM10", "LPT10", "NULL", "console"])
+def test_sanitize_plot_name_does_not_over_match_non_reserved_names(name):
+    """Names that merely resemble a reserved device name (COM10, NULL,
+    console, ...) must not be mangled."""
+    sanitized = MarkdownReportGenerator()._sanitize_plot_name(name)
+    assert sanitized == name
+
+
+def test_a_reserved_device_name_section_title_does_not_collide_on_disk(tmp_path):
+    """End-to-end: a section titled 'NUL' must not produce a plot filename
+    that Windows treats as the NUL device."""
+    waveform = _make_waveform()
+    section = TestSection(title="NUL", waveforms=[waveform])
+    out = tmp_path / "r.md"
+    report = _report(section)
+    assert MarkdownReportGenerator(include_plots=True).generate(report, out) is True
+    plots_path = out.parent / "plots"
+    written = list(plots_path.glob("*.png"))
+    assert len(written) == 1
+    assert written[0].stem.split(".", 1)[0].upper() not in MarkdownReportGenerator._RESERVED_DEVICE_NAMES
+
+
+# --- Defect 4: overlay plot filename collision --------------------------
+
+
+def test_overlay_plots_with_colliding_sanitized_names_do_not_overwrite_each_other(tmp_path):
+    """Two overlay specs in the same section whose channel labels differ
+    only in characters _sanitize_plot_name collapses together ('A/B' and
+    'A:B' both become 'A_B') must not silently overwrite each other's PNG."""
+    waveform = _make_waveform()
+    section = TestSection(title="S")
+    section.overlay_plots = [
+        OverlayPlotSpec(channel_label="A/B", traces=[OverlayTrace("before", waveform, "#1f77b4")]),
+        OverlayPlotSpec(channel_label="A:B", traces=[OverlayTrace("before", waveform, "#1f77b4")]),
+    ]
+    out = tmp_path / "r.md"
+    report = _report(section)
+    assert MarkdownReportGenerator(include_plots=True).generate(report, out) is True
+
+    plots_path = out.parent / "plots"
+    written = list(plots_path.glob("*.png"))
+    assert len(written) == 2


### PR DESCRIPTION
## Summary
- Closes out theme #4 "report escaping" for the Markdown output path (the PDF path shipped in #158): free report text reaching Markdown table cells or image/link alt text is now escaped, so a `|` in a measurement name or a `]` in a waveform/region label can no longer corrupt table rows or links.
- Fixes two related filename-collision gaps in `markdown_generator.py`: Windows reserved device names (`NUL`, `CON`, `COM1`-`9`, etc.) surviving the plot-filename allowlist, and `_generate_overlay_plot` filenames colliding when section titles differ only in sanitized-away characters.

## Test plan
- [x] `pytest tests/test_markdown_generator_escaping.py tests/test_markdown_generator_plot_filenames.py tests/test_markdown_generator_error_handling.py tests/test_markdown_comparison_elements.py -q` — 47 passed
- [x] Independent review pass re-ran the same suite and confirmed the CHANGELOG/docs mirror
