### PR TITLE
fix(report): clamp detect_edges end index to prevent IndexError (H29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`detect_edges` could crash with an `IndexError` on an edge near the end of
+  a waveform record.** Both the rising- and falling-edge loops clamped the
+  edge window's end index to `len(t)` instead of `len(t) - 1`, so a detected
+  edge whose derivative peak fell in the last ~2% of a record with 500 or
+  more samples could push `end_idx` one past the last valid sample, raising
+  `IndexError` and silently dropping all region analysis and transient
+  detection for that waveform. `end_idx` is now clamped to the last valid
+  index.
 - **Translucent fills reached the PDF fully opaque.** `svglib` honours
   `fill-opacity`/`stroke-opacity` but ignores a bare `opacity:`, which is what
   matplotlib writes for a translucent *patch* — so an annotation span drawn at

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -88,6 +88,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`detect_edges` could crash with an `IndexError` on an edge near the end of
+  a waveform record.** Both the rising- and falling-edge loops clamped the
+  edge window's end index to `len(t)` instead of `len(t) - 1`, so a detected
+  edge whose derivative peak fell in the last ~2% of a record with 500 or
+  more samples could push `end_idx` one past the last valid sample, raising
+  `IndexError` and silently dropping all region analysis and transient
+  detection for that waveform. `end_idx` is now clamped to the last valid
+  index.
 - **Translucent fills reached the PDF fully opaque.** `svglib` honours
   `fill-opacity`/`stroke-opacity` but ignores a bare `opacity:`, which is what
   matplotlib writes for a translucent *patch* — so an annotation span drawn at

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -1133,7 +1133,7 @@ class WaveformAnalyzer:
                 # Define edge region as ±5% around the peak
                 window = int(len(t) * 0.02)
                 start_idx = max(0, idx - window)
-                end_idx = min(len(t), idx + window)
+                end_idx = min(len(t) - 1, idx + window)
 
                 edge = WaveformRegion(
                     start_time=float(t[start_idx]),
@@ -1151,7 +1151,7 @@ class WaveformAnalyzer:
             if idx < len(t) - 10:
                 window = int(len(t) * 0.02)
                 start_idx = max(0, idx - window)
-                end_idx = min(len(t), idx + window)
+                end_idx = min(len(t) - 1, idx + window)
 
                 edge = WaveformRegion(
                     start_time=float(t[start_idx]),

--- a/tests/test_waveform_analyzer_transients.py
+++ b/tests/test_waveform_analyzer_transients.py
@@ -9,6 +9,9 @@ unbounded by default, bounded only on request.
 Pure CPU over in-memory arrays -- no instrument, no network.
 """
 
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
 from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 
 
@@ -39,3 +42,31 @@ def test_detect_regions_still_appends_at_most_ten_transients(bursty_waveform):
     WaveformAnalyzer.detect_regions(bursty_waveform, auto_detect_edges=False, auto_detect_transients=True)
 
     assert len([r for r in bursty_waveform.regions if r.region_type == "transient"]) == 10
+
+
+def test_detect_edges_survives_an_edge_near_the_end_of_the_record():
+    """detect_edges used to index t[len(t)] whenever a detected edge's window
+    ran past the last sample -- an IndexError that silently dropped all region
+    analysis for that capture.
+
+    window = int(len(t) * 0.02), so it only reaches >= 10 once the record has
+    >= 500 samples; below that the old clamp (min(len(t), ...)) never actually
+    hit the out-of-bounds case. A 1000-sample record with a step edge at index
+    985 puts the derivative peak at idx=984, inside the `idx < len(t) - 10`
+    guard (984 < 990) but with idx + window = 984 + 20 = 1004 -- past the last
+    valid index (999). This pins the fix: end_idx must clamp to len(t) - 1,
+    not len(t).
+    """
+    n, rate = 1000, 1e6
+    t = np.arange(n) / rate
+    v = np.zeros(n)
+    v[985:] = 5.0  # step edge whose derivative peak lands at idx=984
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+
+    edges = WaveformAnalyzer.detect_edges(waveform)
+
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.region_type == "edge_rising"
+    assert np.isfinite(edge.end_time)
+    assert t[0] <= edge.end_time <= t[-1]


### PR DESCRIPTION
## Summary

- `WaveformAnalyzer.detect_edges` could raise `IndexError` when a detected edge fell in the last ~2% of a waveform record (≥500 samples): `end_idx = min(len(t), idx + window)` permitted `end_idx == len(t)`, one past the last valid index into `t`, which the code then indexed directly.
- Both occurrences (rising-edge loop and falling-edge loop) are clamped to `min(len(t) - 1, idx + window)`.
- Since this exception propagated out of `detect_regions` and both of its callers wrap it in a broad `except Exception: logger.warning(...)`, the practical effect was that region analysis and transient detection for the affected waveform silently vanished from computed reports with only a logged warning.
- This closes finding H29 from the project's adversarial audit — the last unfixed item in the "acquisition-path cluster" theme. The other four findings in that cluster (H2 npz default, H3 batch_capture string scales, H4 fixed-sleep capture_single, H35 WORD-format garbage data) were verified already fixed in prior releases (5.6.0 and later) during this review.

## Test plan

- [x] Added `test_detect_edges_survives_an_edge_near_the_end_of_the_record` (`tests/test_waveform_analyzer_transients.py`) — constructs a 1000-sample record with a step edge at index 985, confirmed it reproduces the exact `IndexError` on the pre-fix code (RED), then passes after the fix (GREEN).
- [x] Independent review mutation-tested the regression test by reverting the fix and re-confirming the same `IndexError` at the same line, then restoring it — the test is a genuine guard, not a false-positive.
- [x] Targeted run: `pytest tests/test_report_tools.py tests/test_waveform_analyzer_transients.py -q` — 33 passed, 0 failed. No other test file exercises `detect_edges`.
- [x] `CHANGELOG.md` / `docs/about/changelog.md` mirror kept in sync (verified byte-identical).
