### PR TITLE
chore(release): 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.0] - 2026-08-27
+
 ### Added
 
 - **Plot annotations in reports.** Waveform, region, FFT and comparison-overlay

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.0] - 2026-08-27
+
 ### Added
 
 - **Plot annotations in reports.** Waveform, region, FFT and comparison-overlay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "7.1.0"
+version = "7.2.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"
 
 from scpi_control.capabilities import ScopeCapabilities
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError


### PR DESCRIPTION
## Summary

Release prep for v7.2.0 (MINOR — new features, no `⚠️ Breaking Changes` section). Follows this repo's release ritual: changelog section inserted above `[Unreleased]`, `docs/about/changelog.md` mirrored, `pyproject.toml` + `scpi_control/__init__.py` versions bumped, PyPI summary re-checked (387/512 chars, unchanged).

### Added
- Plot annotations in reports (text labels, reference lines, shaded spans, figure captions), with an **Annotate…** editor and `<source>.annotations.json` sidecar persistence.
- Dense binary waveform stream + zoomable live view: the gateway's Time canvas now receives up to 100,000 samples/channel as compact binary WebSocket frames, rendered as a min/max envelope with scroll/pinch-zoom and drag-pan.

### Security
- Report-text-derived plot filenames could escape the plots directory (path traversal / NTFS ADS via `:`).
- PDF report text reached ReportLab's markup parser unescaped at most call sites.
- Markdown report text reached table cells and link/alt text unescaped (plus Windows reserved-device-name and filename-collision fixes).

### Changed
- Scope sessions no longer sit on a fixed 0.25s poll floor; PSU/AWG unaffected.
- `InstrumentSession.publish` embedders: waveform/reference messages carry `samples`/`seq` instead of a `points` list (WebSocket JSON contract itself unchanged).

### Fixed
- `detect_edges` `IndexError` on an edge near the end of a record (H29, PR #160).
- Translucent PDF plot fills rendered fully opaque.
- A code span next to bold text could corrupt or crash PDF generation.
- Stale AI-generated summary/findings could ship into a report built from different data.

### Removed
- `WaveformRegion.markers` (unused, superseded by `PlotAnnotation`).

## Test plan

- [x] Full suite: `pytest tests/ -n 8` — 2945 passed, 19 skipped, no regressions.
- [x] `black --check --line-length 200 scpi_control/ examples/` — clean (matches CI's lint scope).
- [x] `flake8 scpi_control/ --select=E9,F63,F7,F82` — 0 errors.
- [x] `tests/test_version_consistency.py` + `tests/test_changelog_mirror.py` — pass.
- [x] PyPI summary length re-checked: 387/512 chars.

Merging this does **not** publish to PyPI — per this repo's release ritual, that's a separate manual `gh workflow run publish.yml` dispatch after tagging, done with explicit go-ahead.
