### PR TITLE
fix(report,mock): clamp find_peaks distance and gate mock PHSE by waveform type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`detect_edges` crashed with `ValueError: 'distance' must be greater or equal to 1`
+  on short waveform records.** The function's only length guard was `len(v) < 10`, so
+  records with 10-19 samples reached `scipy.signal.find_peaks(..., distance=int(len(t)
+  * 0.05))`, which truncates to `0` in that range and scipy rejects `distance < 1`. Any
+  such record with a genuine edge for `find_peaks` to detect (rather than a flat signal
+  that never got that far) crashed edge detection and silently dropped all region
+  analysis for the report. Both `find_peaks` calls in `detect_edges` now clamp
+  `distance=max(1, int(len(t) * 0.05))`.
+- **Mock AWG's `C{ch}:BSWV?` response included a `PHSE` field even for waveform
+  types the SDG manual documents it as invalid for.** Siglent's SDG programming guide
+  (PG02-E05B, p.29-30) states `PHSE` is "Not valid when WVTP is NOISE, PULSE or DC," but
+  the mock appended `PHSE,<value>` to the response unconditionally, so any channel set to
+  one of those three functions answered a query shape the manual explicitly excludes --
+  the same conditional-response-format defect class already fixed for `DUTY`/`SYM`. The
+  mock now omits `PHSE` from the response when the channel's function is `NOISE`,
+  `PULSE`, or `DC`.
+
 ## [7.2.0] - 2026-08-27
 
 ### Added

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`detect_edges` crashed with `ValueError: 'distance' must be greater or equal to 1`
+  on short waveform records.** The function's only length guard was `len(v) < 10`, so
+  records with 10-19 samples reached `scipy.signal.find_peaks(..., distance=int(len(t)
+  * 0.05))`, which truncates to `0` in that range and scipy rejects `distance < 1`. Any
+  such record with a genuine edge for `find_peaks` to detect (rather than a flat signal
+  that never got that far) crashed edge detection and silently dropped all region
+  analysis for the report. Both `find_peaks` calls in `detect_edges` now clamp
+  `distance=max(1, int(len(t) * 0.05))`.
+- **Mock AWG's `C{ch}:BSWV?` response included a `PHSE` field even for waveform
+  types the SDG manual documents it as invalid for.** Siglent's SDG programming guide
+  (PG02-E05B, p.29-30) states `PHSE` is "Not valid when WVTP is NOISE, PULSE or DC," but
+  the mock appended `PHSE,<value>` to the response unconditionally, so any channel set to
+  one of those three functions answered a query shape the manual explicitly excludes --
+  the same conditional-response-format defect class already fixed for `DUTY`/`SYM`. The
+  mock now omits `PHSE` from the response when the channel's function is `NOISE`,
+  `PULSE`, or `DC`.
+
 ## [7.2.0] - 2026-08-27
 
 ### Added

--- a/docs/development/wire-form-inventory.md
+++ b/docs/development/wire-form-inventory.md
@@ -388,7 +388,7 @@ appended only for SQUARE/PULSE, `SYM` only for RAMP (p.29-30 parameter table).
 | `get_output` | `C{ch}:OUTP?` | `<channel>:OUTPut?` returns `ON\|OFF,LOAD,<load>,PLRT,<polarity>` together; `STATE` read out of it | VERIFIED | PG02-E05B p.27-28 |
 | `get_output_load` | `C{ch}:OUTP?` | same whole-list `<channel>:OUTPut?` reply as `get_output`; dead code (no caller), verified at command-table/mock level only | VERIFIED | PG02-E05B p.27-28 |
 | `get_output_polarity` | `C{ch}:OUTP?` | same whole-list `<channel>:OUTPut?` reply as `get_output`; dead code (no caller), verified at command-table/mock level only | VERIFIED | PG02-E05B p.27-28 |
-| `get_phase` | `C{ch}:BSWV?` | `<channel>:BaSic_WaVe?` returns every BSWV parameter as one comma-joined reply; `PHSE` read out of it | VERIFIED | PG02-E05B p.31 |
+| `get_phase` | `C{ch}:BSWV?` | `<channel>:BaSic_WaVe?` returns every BSWV parameter as one comma-joined reply; `PHSE` only present when WVTP is not NOISE/PULSE/DC, read out of it | VERIFIED | PG02-E05B p.31, p.29-30 |
 | `get_pulse_duty` | `C{ch}:BSWV?` | `<channel>:BaSic_WaVe?` returns every BSWV parameter as one comma-joined reply; `DUTY` only present when WVTP is SQUARE/PULSE, read out of it | VERIFIED | PG02-E05B p.31, p.29 |
 | `get_ramp_symmetry` | `C{ch}:BSWV?` | `<channel>:BaSic_WaVe?` returns every BSWV parameter as one comma-joined reply; `SYM` only present when WVTP is RAMP, read out of it | VERIFIED | PG02-E05B p.31, p.30 |
 | `get_sweep_state` | `C{ch}:SWWV?` | bare `<channel>:SWeepWaVe?`; future-expansion command, no getter/mock/parser wired, request-only | VERIFIED | PG02-E05B p.38 |
@@ -402,7 +402,7 @@ appended only for SQUARE/PULSE, `SYM` only for RAMP (p.29-30 parameter table).
 | `set_output` | `C{ch}:OUTP {state}` | `<channel>:OUTPut ON\|OFF` (state independently settable per the worked EXAMPLEs) | VERIFIED | PG02-E05B p.28 |
 | `set_output_load` | `C{ch}:OUTP LOAD,{load}` | `<channel>:OUTPut LOAD,<load>`; not mocked | VERIFIED | PG02-E05B p.28 |
 | `set_output_polarity` | `C{ch}:OUTP PLRT,{polarity}` | `<channel>:OUTPut PLRT,<polarity>`; not mocked, dead code (no caller) | VERIFIED | PG02-E05B p.28 |
-| `set_phase` | `C{ch}:BSWV PHSE,{phase}` | `<channel>:BaSic_WaVe PHSE,<phase>` | VERIFIED | PG02-E05B p.29-30, p.31 |
+| `set_phase` | `C{ch}:BSWV PHSE,{phase}` | `<channel>:BaSic_WaVe PHSE,<phase>`; not valid when WVTP is NOISE, PULSE, or DC | VERIFIED | PG02-E05B p.29-30, p.31 |
 | `set_pulse_duty` | `C{ch}:BSWV DUTY,{duty}` | `<channel>:BaSic_WaVe DUTY,<duty>` | VERIFIED | PG02-E05B p.29-30 |
 | `set_ramp_symmetry` | `C{ch}:BSWV SYM,{symmetry}` | `<channel>:BaSic_WaVe SYM,<symmetry>` | VERIFIED | PG02-E05B p.29-30 |
 | `set_sweep_state` | `C{ch}:SWWV STATE,{state}` | `<channel>:SweepWaVe STATE,<state>`; not mocked, dead code (no caller) | VERIFIED | PG02-E05B p.37, p.39 |

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -803,6 +803,9 @@ class MockConnection(BaseConnection):
             # appends them when the channel's current function calls for them
             # (H5 follow-up: the mock used to always emit DUTY,SYM and never
             # HLEV,LLEV, a shape the manual never shows for any waveform type).
+            # PHSE is likewise conditional: p.29-30 says "Not valid when WVTP
+            # is NOISE, PULSE or DC" -- unlike DUTY/SYM this was missed on the
+            # first pass and appended unconditionally until this fix.
             if match := re.match(r"C(\d+):BSWV\?$", upper):
                 ch = int(match.group(1))
                 c = self.awg_channels.get(ch, {})
@@ -814,15 +817,10 @@ class MockConnection(BaseConnection):
                 hlev = offset + amplitude / 2
                 llev = offset - amplitude / 2
                 response = (
-                    f"C{ch}:BSWV WVTP,{function},"
-                    f"FRQ,{frequency:.10g}HZ,"
-                    f"PERI,{period:.10g}S,"
-                    f"AMP,{amplitude:.10g}V,"
-                    f"OFST,{offset:.10g}V,"
-                    f"HLEV,{hlev:.10g}V,"
-                    f"LLEV,{llev:.10g}V,"
-                    f"PHSE,{c.get('phase', 0.0):.10g}"
+                    f"C{ch}:BSWV WVTP,{function}," f"FRQ,{frequency:.10g}HZ," f"PERI,{period:.10g}S," f"AMP,{amplitude:.10g}V," f"OFST,{offset:.10g}V," f"HLEV,{hlev:.10g}V," f"LLEV,{llev:.10g}V"
                 )
+                if function not in ("NOISE", "PULSE", "DC"):
+                    response += f",PHSE,{c.get('phase', 0.0):.10g}"
                 if function in ("SQUARE", "PULSE"):
                     response += f",DUTY,{c.get('pulse_duty', 50.0):.10g}"
                 elif function == "RAMP":

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -1127,7 +1127,7 @@ class WaveformAnalyzer:
         edges = []
 
         # Find rising edges
-        rising_peaks, _ = scipy_signal.find_peaks(derivative, height=threshold, distance=int(len(t) * 0.05))
+        rising_peaks, _ = scipy_signal.find_peaks(derivative, height=threshold, distance=max(1, int(len(t) * 0.05)))
         for idx in rising_peaks[: max_edges // 2]:
             if idx < len(t) - 10:
                 # Define edge region as ±5% around the peak
@@ -1146,7 +1146,7 @@ class WaveformAnalyzer:
                 edges.append(edge)
 
         # Find falling edges
-        falling_peaks, _ = scipy_signal.find_peaks(-derivative, height=threshold, distance=int(len(t) * 0.05))
+        falling_peaks, _ = scipy_signal.find_peaks(-derivative, height=threshold, distance=max(1, int(len(t) * 0.05)))
         for idx in falling_peaks[: max_edges // 2]:
             if idx < len(t) - 10:
                 window = int(len(t) * 0.02)

--- a/tests/test_function_generator.py
+++ b/tests/test_function_generator.py
@@ -287,6 +287,48 @@ class TestAWGOutput:
         assert config["enabled"] is True
 
 
+class TestBSWVResponsePhaseConditional:
+    """C{ch}:BSWV? must not carry a PHSE token for functions the manual
+    says it's invalid for.
+
+    SDG_ProgrammingGuide_PG02-E05B.pdf p.29-30, BaSic_WaVe parameter table:
+    "PHSE <phase> := {0 to 360}. The unit is 'degree'. Not valid when WVTP
+    is NOISE, PULSE or DC." The mock used to append PHSE unconditionally to
+    the base response string, so any channel set to one of those three
+    functions answered a query shape the manual explicitly excludes --
+    same conditional-response-format defect class DUTY/SYM were already
+    fixed for (H5 follow-up), just missed for PHSE.
+    """
+
+    @pytest.fixture
+    def mock_awg(self):
+        """Create mock AWG connection."""
+        conn = MockConnection(
+            awg_mode=True,
+            awg_idn="Siglent Technologies,SDG1032X,SDG1XXXXX,2.01.01.37R1",
+        )
+        awg = FunctionGenerator("mock", connection=conn)
+        awg.connect()
+        return awg
+
+    def test_sine_response_still_includes_phse(self, mock_awg):
+        """Control case: SINE is not in the excluded set, so PHSE stays."""
+        mock_awg.channel1.function = "SINE"
+
+        response = mock_awg.query("C1:BSWV?")
+
+        assert "PHSE," in response
+
+    @pytest.mark.parametrize("function", ["PULSE", "NOISE", "DC"])
+    def test_excluded_functions_omit_phse(self, mock_awg, function):
+        """PHSE must not appear when WVTP is NOISE, PULSE, or DC (p.29-30)."""
+        mock_awg.channel1.function = function
+
+        response = mock_awg.query("C1:BSWV?")
+
+        assert "PHSE," not in response, f"{function} response should not carry PHSE: {response!r}"
+
+
 class TestFunctionGeneratorOperations:
     """Test overall AWG operations."""
 

--- a/tests/test_waveform_analyzer_transients.py
+++ b/tests/test_waveform_analyzer_transients.py
@@ -70,3 +70,33 @@ def test_detect_edges_survives_an_edge_near_the_end_of_the_record():
     assert edge.region_type == "edge_rising"
     assert np.isfinite(edge.end_time)
     assert t[0] <= edge.end_time <= t[-1]
+
+
+def test_detect_edges_survives_a_short_record_with_a_genuine_edge():
+    """Both find_peaks calls pass distance=int(len(t) * 0.05), which truncates
+    to 0 for any record with 10 <= len(t) <= 19 -- the function's only length
+    guard is `if len(v) < 10: return []`, so records in that range reach
+    find_peaks. scipy.signal.find_peaks requires distance >= 1 and raises
+    ValueError('distance must be greater or equal to 1') for distance=0,
+    which is a different root cause than H29's IndexError (this one is
+    rejected before any indexing happens) despite living in the same
+    function and same failure family.
+
+    A 15-sample record with a step edge at index 3 gives a single, sharp
+    derivative peak (idx=2) well above the height threshold, so find_peaks
+    has something to find and actually reaches the distance=0 call. This
+    pins the fix: distance must clamp to max(1, int(len(t) * 0.05)).
+    """
+    n, rate = 15, 1e6
+    t = np.arange(n) / rate
+    v = np.zeros(n)
+    v[3:] = 5.0  # step edge whose derivative peak lands at idx=2
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+
+    edges = WaveformAnalyzer.detect_edges(waveform)
+
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.region_type == "edge_rising"
+    assert np.isfinite(edge.end_time)
+    assert t[0] <= edge.end_time <= t[-1]

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -1926,7 +1926,7 @@ WIRE_FORMS: List[WireForm] = [
         op="get_pulse_duty",
         params={"ch": 1},
         request="C1:BSWV?",
-        response="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,1V,OFST,0V,HLEV,0.5V,LLEV,-0.5V,PHSE,0,DUTY,50",
+        response="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,1V,OFST,0V,HLEV,0.5V,LLEV,-0.5V,DUTY,50",
         parsed=50.0,
         source=f"{SDG_GUIDE} p.31, p.29",
         mock_kwargs={
@@ -1941,7 +1941,12 @@ WIRE_FORMS: List[WireForm] = [
             "channel is configured PULSE via mock_kwargs to get a response "
             "shape the manual actually documents as containing DUTY. On the "
             "default SINE channel this getter now honestly raises "
-            "CommandError (no DUTY field), matching real hardware."
+            "CommandError (no DUTY field), matching real hardware. PHSE is "
+            "also absent here -- fix wave 2 follow-up: the same p.29-30 "
+            "table says PHSE is 'Not valid when WVTP is NOISE, PULSE or DC', "
+            "and the mock used to append it unconditionally regardless of "
+            "function; this response pins the corrected PULSE shape with no "
+            "PHSE token."
         ),
     ),
     # p.29-30 parameter table: "SYM <symmetry> := {0 to 100}. Symmetry of "


### PR DESCRIPTION
## Summary

Two small, independent bug fixes, bundled together:

### 1. `detect_edges` crashed on short records with a genuine edge
`scpi_control/report_generator/utils/waveform_analyzer.py`: both `find_peaks` calls in `detect_edges` used `distance=int(len(t) * 0.05)`, which truncates to `0` for `10 <= len(t) <= 19`. `scipy.signal.find_peaks` rejects `distance=0` with `ValueError`. Clamped both to `max(1, int(len(t) * 0.05))`. Found during review of PR #160 (the sibling `IndexError` fix in this same function).

### 2. Mock AWG's `BSWV?` reported `PHSE` for waveform types where it's invalid
`scpi_control/connection/mock/base.py`: the mock's `C{ch}:BSWV?` handler always included `PHSE,<value>`. Verified directly against the vendor manual (`SDG_ProgrammingGuide_PG02-E05B.pdf`, p.29-30): `PHSE` is "Not valid when WVTP is NOISE, PULSE or DC." `PHSE` is now appended conditionally, the same way `DUTY`/`SYM` already are for their own applicable waveform types. Updated `docs/development/wire-form-inventory.md`'s `get_phase`/`set_phase` rows to carry the same function-conditional caveat, and updated `tests/wire_forms.py`'s hardcoded PULSE `BSWV?` expectation (used by the wire-conformance corpus) to match.

This closes out the last two items from the project's adversarial audit's mock-fidelity/correctness backlog (the `find_peaks` crash was a new finding surfaced during PR #160's review; the `PHSE` gap was the deferred "mock physics coherence" follow-up from the audit's theme #3).

## Test plan

- [x] Both bugs fixed via TDD: regression test added first, confirmed it fails on unpatched code with the exact reported error, then passes after the fix.
- [x] Independent review mutation-tested both fixes (reverted each in isolation, confirmed the exact same failure reappears, restored) — both regression tests are genuine guards.
- [x] Independent review extracted the vendor manual pages directly via PyMuPDF and confirmed the `PHSE` exclusion list matches the code exactly, and confirmed the response's field ordering/comma-formatting stays well-formed for every waveform type (including the two combined-conditional cases, SQUARE and RAMP).
- [x] Targeted run: `pytest tests/test_waveform_analyzer_transients.py tests/test_function_generator.py tests/test_wire_conformance.py tests/test_sdg_response_parsing.py tests/test_server_awg.py -q` — 248 passed.
- [x] Full suite: `pytest tests/ -n 8` — 2950 passed, 19 skipped, no regressions.
- [x] `black --check --line-length 200 scpi_control/ examples/` — clean. `flake8 scpi_control/ --select=E9,F63,F7,F82` — 0 errors.
- [x] `CHANGELOG.md` / `docs/about/changelog.md` mirror kept in sync (verified byte-identical).
