### PR TITLE
feat: measurement uncertainty and unit-aware quantities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,web]" httpx "ollama>=0.6.0"  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests
+          pip install -e ".[dev,web,uncertainty]" httpx "ollama>=0.6.0"  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests; uncertainty: pint/uncertainties for measurement-uncertainty tests
           pip install pytest pytest-cov pytest-xdist pytest-timeout  # pytest-timeout: tests/test_server_stream_ws.py is marked, and --strict-markers errors without the plugin
 
       - name: Run tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest tests/ --cov=scpi_control --cov-report=xml --cov-report=term-missing -v
+          pytest tests/ --run-llm --cov=scpi_control --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Measurement uncertainty and unit-aware quantities**, opt-in via the new
+  `uncertainty` extra (`pip install "SCPI-Instrument-Control[uncertainty]"`,
+  adds `pint`/`uncertainties`). `WaveformAnalyzer.compute_statistical_quantity`
+  computes mean ± sample standard deviation across N repeated captures of
+  the same measurement (e.g. `vpp` across several `batch_capture` triggers)
+  as a unit-aware `Quantity` (`scpi_control.quantities`). Attach the result
+  to a waveform's new `uncertain_statistics` field and both the PDF and
+  Markdown report generators render it as "1.23 ± 0.012 V" in place of the
+  plain value, with no other change to existing reports. Also new: a
+  pluggable per-instrument accuracy-spec registry
+  (`scpi_control.instrument_specs`) — ships with real structure and zero
+  populated entries, since only programming guides (not datasheets with
+  accuracy tables) are in this repo; real formulas are added later from
+  real datasheet citations. No existing method's return type changed.
+
 ### Fixed
 
 - **`detect_edges` crashed with `ValueError: 'distance' must be greater or equal to 1`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Measurement uncertainty and unit-aware quantities**, opt-in via the new
+  `uncertainty` extra (`pip install "SCPI-Instrument-Control[uncertainty]"`,
+  adds `pint`/`uncertainties`). `WaveformAnalyzer.compute_statistical_quantity`
+  computes mean ± sample standard deviation across N repeated captures of
+  the same measurement (e.g. `vpp` across several `batch_capture` triggers)
+  as a unit-aware `Quantity` (`scpi_control.quantities`). Attach the result
+  to a waveform's new `uncertain_statistics` field and both the PDF and
+  Markdown report generators render it as "1.23 ± 0.012 V" in place of the
+  plain value, with no other change to existing reports. Also new: a
+  pluggable per-instrument accuracy-spec registry
+  (`scpi_control.instrument_specs`) — ships with real structure and zero
+  populated entries, since only programming guides (not datasheets with
+  accuracy tables) are in this repo; real formulas are added later from
+  real datasheet citations. No existing method's return type changed.
+
 ### Fixed
 
 - **`detect_edges` crashed with `ValueError: 'distance' must be greater or equal to 1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ markers = [
     "hardware: tests that require actual oscilloscope hardware",
     "gui: tests that require GUI dependencies (PyQt6)",
     "slow: tests that run examples as subprocesses (deselect with -m 'not slow')",
+    "llm: tests that exercise the optional LLM-analysis feature; skipped by default, run with --run-llm",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ report-generator = [
     "psutil>=5.9.0",
     "nvidia-ml-py>=12.0.0",
 ]
+uncertainty = [
+    "pint>=0.24",
+    "uncertainties>=3.2",
+]
 # Experimental features (BETA - v0.4.0-beta.1)
 # Power supply control - no additional dependencies required
 # Included for explicit feature installation and documentation
@@ -140,6 +144,8 @@ all = [
     "PyMuPDF>=1.23.0",
     "psutil>=5.9.0",
     "nvidia-ml-py>=12.0.0",
+    "pint>=0.24",
+    "uncertainties>=3.2",
     # Note: Experimental features not included in 'all'
     # Install explicitly with [power-supply-beta] or [experimental]
 ]

--- a/scpi_control/instrument_specs.py
+++ b/scpi_control/instrument_specs.py
@@ -1,0 +1,48 @@
+"""Pluggable per-instrument measurement-accuracy formulas.
+
+Ships with an empty registry. This repo does not fabricate accuracy numbers
+it hasn't verified against a real datasheet (see AUDIT.md C1/C2 for what
+happens when it did, historically, for other computed metrics) -- only
+programming guides, not datasheets, are downloaded in docs/. Populate real
+entries via `register_accuracy_spec` once you have a real datasheet citation.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from scpi_control.exceptions import InvalidParameterError
+
+
+@dataclass(frozen=True)
+class AccuracySpec:
+    """One documented accuracy formula.
+
+    e.g. "+/-(3% of reading + 0.5% of full scale)" becomes
+    `lambda reading, full_scale: abs(reading) * 0.03 + full_scale * 0.005`.
+
+    Attributes:
+        formula: (reading, full_scale) -> absolute uncertainty, in the
+            reading's own unit.
+        source: Where this formula came from -- required, not optional, so
+            an entry cannot be registered without a citation (e.g.
+            "SDS824X HD datasheet DS0503X-E01B, p.4, vertical accuracy
+            table").
+    """
+
+    formula: Callable[[float, float], float]
+    source: str
+
+
+_REGISTRY: Dict[Tuple[str, str, str], AccuracySpec] = {}
+
+
+def register_accuracy_spec(manufacturer: str, model: str, measurement_type: str, spec: AccuracySpec) -> None:
+    """Register a real, cited accuracy formula for one instrument + measurement type."""
+    if not spec.source.strip():
+        raise InvalidParameterError("AccuracySpec.source must cite where the formula came from, not be empty")
+    _REGISTRY[(manufacturer, model, measurement_type)] = spec
+
+
+def lookup_accuracy_spec(manufacturer: str, model: str, measurement_type: str) -> Optional[AccuracySpec]:
+    """The registered spec, or None if nothing is on file -- never a guess."""
+    return _REGISTRY.get((manufacturer, model, measurement_type))

--- a/scpi_control/quantities.py
+++ b/scpi_control/quantities.py
@@ -1,0 +1,62 @@
+"""Unit-aware quantities with optional measurement uncertainty.
+
+Wraps `pint` (dimensional analysis: a Quantity carries its unit, and
+mismatched-dimension arithmetic raises instead of silently producing a
+meaningless number) and `uncertainties` (a `ufloat` magnitude propagates
+value +/- error correctly through arithmetic). One module-level
+UnitRegistry -- pint's own documentation is explicit that Quantity objects
+from two different registries compare unequal to each other, so every
+Quantity in this codebase must come from THIS registry, via `quantity()`.
+
+Optional dependency: requires the `uncertainty` extra
+(`pip install "SCPI-Instrument-Control[uncertainty]"`). Nothing else in this
+package imports this module at top level -- every caller does a local
+import, so installing scpi_control (or even scpi_control[report-generator])
+does not pull in pint/uncertainties unless uncertainty features are
+actually used.
+"""
+
+from typing import Optional
+
+try:
+    import pint
+    from uncertainties import ufloat
+except ImportError:
+    raise ImportError("pint and uncertainties are required for measurement-uncertainty support. " 'Install with: pip install "SCPI-Instrument-Control[uncertainty]"')
+
+_REGISTRY = pint.UnitRegistry()
+Quantity = _REGISTRY.Quantity
+
+
+def quantity(value: float, unit: str, uncertainty: Optional[float] = None) -> Quantity:
+    """Build a Quantity, optionally carrying a symmetric 1-sigma uncertainty.
+
+    Args:
+        value: The nominal value, in `unit`.
+        unit: A pint-recognized unit string, e.g. "V", "Hz", "s", "percent".
+        uncertainty: 1-sigma uncertainty in the same `unit`, or None for an
+            exact/unmeasured-spread value.
+
+    Returns:
+        A Quantity whose magnitude is a plain float (no uncertainty given)
+        or an `uncertainties.ufloat` (uncertainty given).
+    """
+    magnitude = ufloat(value, uncertainty) if uncertainty is not None else value
+    return _REGISTRY.Quantity(magnitude, unit)
+
+
+def format_quantity(q: Quantity, precision: int = 3) -> str:
+    """'1.23 +/- 0.012 V' (compact SI prefix) or '3 V' with no uncertainty.
+
+    Args:
+        q: A Quantity built by `quantity()`.
+        precision: Significant figures for both the nominal value and the
+            uncertainty (independently -- matches how each is individually
+            meaningful, not a shared decimal-place count).
+    """
+    compact = q.to_compact()
+    magnitude = compact.magnitude
+    unit_str = format(compact.units, "~")
+    if hasattr(magnitude, "nominal_value"):
+        return f"{magnitude.nominal_value:.{precision}g} ± {magnitude.std_dev:.{precision}g} {unit_str}"
+    return f"{magnitude:.{precision}g} {unit_str}"

--- a/scpi_control/quantities.py
+++ b/scpi_control/quantities.py
@@ -54,9 +54,17 @@ def format_quantity(q: Quantity, precision: int = 3) -> str:
             uncertainty (independently -- matches how each is individually
             meaningful, not a shared decimal-place count).
     """
-    compact = q.to_compact()
-    magnitude = compact.magnitude
-    unit_str = format(compact.units, "~")
+    magnitude = q.magnitude
     if hasattr(magnitude, "nominal_value"):
-        return f"{magnitude.nominal_value:.{precision}g} ± {magnitude.std_dev:.{precision}g} {unit_str}"
-    return f"{magnitude:.{precision}g} {unit_str}"
+        # pint's to_compact() internally does an implicit float() conversion
+        # to pick a scale, which `uncertainties` deliberately forbids on a
+        # ufloat. Compact using the plain nominal value only, then convert
+        # the std_dev into whatever unit that picked -- never hand a ufloat
+        # magnitude to to_compact() itself.
+        nominal_compact = _REGISTRY.Quantity(magnitude.nominal_value, q.units).to_compact()
+        unit_str = format(nominal_compact.units, "~")
+        std_dev_converted = _REGISTRY.Quantity(magnitude.std_dev, q.units).to(nominal_compact.units)
+        return f"{nominal_compact.magnitude:.{precision}g} ± {std_dev_converted.magnitude:.{precision}g} {unit_str}"
+    compact = q.to_compact()
+    unit_str = format(compact.units, "~")
+    return f"{compact.magnitude:.{precision}g} {unit_str}"

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -31,6 +31,14 @@ def _format_stat(waveform: WaveformData, stat: str) -> str:
     return waveform.format_statistic(stat)
 
 
+def _stat_available(waveform: WaveformData, stat: str) -> bool:
+    """True if `_format_stat` has something to render for this stat, whether
+    that comes from `uncertain_statistics` or the plain `statistics` dict."""
+    if waveform.uncertain_statistics and stat in waveform.uncertain_statistics:
+        return True
+    return bool(waveform.statistics) and stat in waveform.statistics and waveform.statistics[stat] is not None
+
+
 class MarkdownReportGenerator(BaseReportGenerator):
     """Generator for Markdown format reports."""
 
@@ -336,7 +344,7 @@ class MarkdownReportGenerator(BaseReportGenerator):
             lines.append(f"| **Signal Type** | **{waveform.signal_type.capitalize()}**{confidence_str} |")
 
         # Enhanced Statistics (if available)
-        if waveform.statistics:
+        if waveform.statistics or waveform.uncertain_statistics:
             lines.append("")
             lines.append("**Signal Statistics:**")
             lines.append("")
@@ -345,28 +353,28 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
             # Amplitude measurements
             for stat in ["vmax", "vmin", "vpp", "vrms", "vmean", "dc_offset"]:
-                if stat in waveform.statistics and waveform.statistics[stat] is not None:
+                if _stat_available(waveform, stat):
                     formatted = _format_stat(waveform, stat)
                     stat_label = stat.upper() if len(stat) <= 4 else stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Frequency and timing
             for stat in ["frequency", "period", "rise_time", "fall_time", "pulse_width", "duty_cycle"]:
-                if stat in waveform.statistics and waveform.statistics[stat] is not None:
+                if _stat_available(waveform, stat):
                     formatted = _format_stat(waveform, stat)
                     stat_label = stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Quality metrics
             for stat in ["snr", "thd", "noise_level", "overshoot", "undershoot", "jitter"]:
-                if stat in waveform.statistics and waveform.statistics[stat] is not None:
+                if _stat_available(waveform, stat):
                     formatted = _format_stat(waveform, stat)
                     stat_label = stat.upper() if stat in ["snr", "thd"] else stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Plateau stability metrics (if calculated)
             for stat in ["plateau_stability", "plateau_high_noise", "plateau_low_noise"]:
-                if stat in waveform.statistics and waveform.statistics[stat] is not None:
+                if _stat_available(waveform, stat):
                     formatted = _format_stat(waveform, stat)
                     stat_label = stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -21,6 +21,16 @@ from scpi_control.report_generator.models.report_data import MeasurementResult, 
 logger = logging.getLogger(__name__)
 
 
+def _format_stat(waveform: WaveformData, stat: str) -> str:
+    """Prefer an uncertainty-carrying Quantity when the caller attached one
+    for this stat; fall back to the existing plain-float formatting."""
+    if waveform.uncertain_statistics and stat in waveform.uncertain_statistics:
+        from scpi_control.quantities import format_quantity  # local: keeps `uncertainty` optional
+
+        return format_quantity(waveform.uncertain_statistics[stat])
+    return waveform.format_statistic(stat)
+
+
 class MarkdownReportGenerator(BaseReportGenerator):
     """Generator for Markdown format reports."""
 
@@ -336,28 +346,28 @@ class MarkdownReportGenerator(BaseReportGenerator):
             # Amplitude measurements
             for stat in ["vmax", "vmin", "vpp", "vrms", "vmean", "dc_offset"]:
                 if stat in waveform.statistics and waveform.statistics[stat] is not None:
-                    formatted = waveform.format_statistic(stat)
+                    formatted = _format_stat(waveform, stat)
                     stat_label = stat.upper() if len(stat) <= 4 else stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Frequency and timing
             for stat in ["frequency", "period", "rise_time", "fall_time", "pulse_width", "duty_cycle"]:
                 if stat in waveform.statistics and waveform.statistics[stat] is not None:
-                    formatted = waveform.format_statistic(stat)
+                    formatted = _format_stat(waveform, stat)
                     stat_label = stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Quality metrics
             for stat in ["snr", "thd", "noise_level", "overshoot", "undershoot", "jitter"]:
                 if stat in waveform.statistics and waveform.statistics[stat] is not None:
-                    formatted = waveform.format_statistic(stat)
+                    formatted = _format_stat(waveform, stat)
                     stat_label = stat.upper() if stat in ["snr", "thd"] else stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 
             # Plateau stability metrics (if calculated)
             for stat in ["plateau_stability", "plateau_high_noise", "plateau_low_noise"]:
                 if stat in waveform.statistics and waveform.statistics[stat] is not None:
-                    formatted = waveform.format_statistic(stat)
+                    formatted = _format_stat(waveform, stat)
                     stat_label = stat.replace("_", " ").title()
                     lines.append(f"| {stat_label} | {formatted} |")
 

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -1125,6 +1125,16 @@ class PDFReportGenerator(BaseReportGenerator):
         # Build table data based on enabled categories
         data = [["Statistic", "Value"]]  # Header
 
+        def _stat_row(label: str, name: str) -> None:
+            """Append one [label, value] row, preferring an uncertainty-
+            carrying Quantity over the plain-float stats dict when present."""
+            if waveform.uncertain_statistics and name in waveform.uncertain_statistics:
+                from scpi_control.quantities import format_quantity  # local: keeps `uncertainty` optional
+
+                data.append([label, format_quantity(waveform.uncertain_statistics[name])])
+            elif stats.get(name) is not None:
+                data.append([label, WaveformAnalyzer.format_stat_value(name, stats[name])])
+
         # Signal Type (always show if detected)
         if stats.get("signal_type"):
             signal_type_str = WaveformAnalyzer.format_stat_value("signal_type", stats["signal_type"])
@@ -1135,62 +1145,40 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Frequency and Period
         if self.report_options.include_frequency_stats:
-            if stats.get("frequency") is not None:
-                data.append(["Frequency:", WaveformAnalyzer.format_stat_value("frequency", stats["frequency"])])
-            if stats.get("period") is not None:
-                data.append(["Period:", WaveformAnalyzer.format_stat_value("period", stats["period"])])
+            _stat_row("Frequency:", "frequency")
+            _stat_row("Period:", "period")
 
         # Amplitude Measurements
         if self.report_options.include_amplitude_stats:
-            if stats.get("vmax") is not None:
-                data.append(["Vmax:", WaveformAnalyzer.format_stat_value("vmax", stats["vmax"])])
-            if stats.get("vmin") is not None:
-                data.append(["Vmin:", WaveformAnalyzer.format_stat_value("vmin", stats["vmin"])])
-            if stats.get("vpp") is not None:
-                data.append(["Vpp:", WaveformAnalyzer.format_stat_value("vpp", stats["vpp"])])
-            if stats.get("vmean") is not None:
-                data.append(["Vmean:", WaveformAnalyzer.format_stat_value("vmean", stats["vmean"])])
-            if stats.get("vrms") is not None:
-                data.append(["Vrms:", WaveformAnalyzer.format_stat_value("vrms", stats["vrms"])])
-            if stats.get("vamp") is not None:
-                data.append(["Vamp:", WaveformAnalyzer.format_stat_value("vamp", stats["vamp"])])
-            if stats.get("dc_offset") is not None:
-                data.append(["DC Offset:", WaveformAnalyzer.format_stat_value("dc_offset", stats["dc_offset"])])
+            _stat_row("Vmax:", "vmax")
+            _stat_row("Vmin:", "vmin")
+            _stat_row("Vpp:", "vpp")
+            _stat_row("Vmean:", "vmean")
+            _stat_row("Vrms:", "vrms")
+            _stat_row("Vamp:", "vamp")
+            _stat_row("DC Offset:", "dc_offset")
 
         # Timing Measurements
         if self.report_options.include_timing_stats:
-            if stats.get("rise_time") is not None:
-                data.append(["Rise Time:", WaveformAnalyzer.format_stat_value("rise_time", stats["rise_time"])])
-            if stats.get("fall_time") is not None:
-                data.append(["Fall Time:", WaveformAnalyzer.format_stat_value("fall_time", stats["fall_time"])])
-            if stats.get("pulse_width") is not None:
-                data.append(["Pulse Width:", WaveformAnalyzer.format_stat_value("pulse_width", stats["pulse_width"])])
-            if stats.get("duty_cycle") is not None:
-                data.append(["Duty Cycle:", WaveformAnalyzer.format_stat_value("duty_cycle", stats["duty_cycle"])])
+            _stat_row("Rise Time:", "rise_time")
+            _stat_row("Fall Time:", "fall_time")
+            _stat_row("Pulse Width:", "pulse_width")
+            _stat_row("Duty Cycle:", "duty_cycle")
 
         # Signal Quality Metrics
         if self.report_options.include_quality_stats:
-            if stats.get("noise_level") is not None:
-                data.append(["Noise Level:", WaveformAnalyzer.format_stat_value("noise_level", stats["noise_level"])])
-            if stats.get("snr") is not None:
-                data.append(["SNR:", WaveformAnalyzer.format_stat_value("snr", stats["snr"])])
-            if stats.get("thd") is not None:
-                data.append(["THD:", WaveformAnalyzer.format_stat_value("thd", stats["thd"])])
-            if stats.get("overshoot") is not None:
-                data.append(["Overshoot:", WaveformAnalyzer.format_stat_value("overshoot", stats["overshoot"])])
-            if stats.get("undershoot") is not None:
-                data.append(["Undershoot:", WaveformAnalyzer.format_stat_value("undershoot", stats["undershoot"])])
-            if stats.get("jitter") is not None:
-                data.append(["Jitter:", WaveformAnalyzer.format_stat_value("jitter", stats["jitter"])])
+            _stat_row("Noise Level:", "noise_level")
+            _stat_row("SNR:", "snr")
+            _stat_row("THD:", "thd")
+            _stat_row("Overshoot:", "overshoot")
+            _stat_row("Undershoot:", "undershoot")
+            _stat_row("Jitter:", "jitter")
 
         # Plateau Stability (if enabled and calculated)
         if self.report_options.include_plateau_stability:
-            if stats.get("plateau_stability") is not None:
-                data.append(["Plateau Stability:", WaveformAnalyzer.format_stat_value("plateau_stability", stats["plateau_stability"])])
-            if stats.get("plateau_high_noise") is not None:
-                data.append(["High Plateau Noise:", WaveformAnalyzer.format_stat_value("plateau_high_noise", stats["plateau_high_noise"])])
-            if stats.get("plateau_low_noise") is not None:
-                data.append(["Low Plateau Noise:", WaveformAnalyzer.format_stat_value("plateau_low_noise", stats["plateau_low_noise"])])
+            _stat_row("Plateau Stability:", "plateau_stability")
+            _stat_row("High Plateau Noise:", "plateau_high_noise")
+            _stat_row("Low Plateau Noise:", "plateau_low_noise")
 
         # If only header row exists, don't create table
         if len(data) <= 1:

--- a/scpi_control/report_generator/models/report_data.py
+++ b/scpi_control/report_generator/models/report_data.py
@@ -8,13 +8,16 @@ including waveform data, measurements, metadata, and report sections.
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
 from scpi_control.waveform import WaveformData as CaptureWaveform
 from scpi_control.report_generator.models.annotations import PlotAnnotation
 from scpi_control.report_generator.models.report_elements import ComparisonTable, DataManifest, OverlayPlotSpec, SignoffBlock
+
+if TYPE_CHECKING:
+    from scpi_control.quantities import Quantity
 
 SUMMARY_SOURCE_MANUAL = "manual"
 SUMMARY_SOURCE_AI = "ai"
@@ -221,6 +224,13 @@ class WaveformData(CaptureWaveform):
     signal_type_confidence: Optional[float] = None
     statistics: Optional[Dict[str, Any]] = None
 
+    # Uncertainty-carrying statistics, additive alongside `statistics` above.
+    # Never set by analyze() (a single capture has no spread to measure) --
+    # a caller populates this from WaveformAnalyzer.compute_statistical_quantity
+    # across repeated captures. String-annotated so this file never needs the
+    # optional `uncertainty` extra just to import.
+    uncertain_statistics: Optional[Dict[str, "Quantity"]] = None
+
     # Regions of interest for detailed analysis
     regions: List[WaveformRegion] = field(default_factory=list)
 
@@ -380,6 +390,18 @@ class WaveformData(CaptureWaveform):
                         stats_serializable[key] = value
             if stats_serializable:
                 data["statistics"] = stats_serializable
+
+        # Add uncertain_statistics (each Quantity -> a JSON-safe {value, uncertainty, unit} dict)
+        if self.uncertain_statistics:
+            uncertain_serializable = {}
+            for key, q in self.uncertain_statistics.items():
+                magnitude = q.magnitude
+                if hasattr(magnitude, "nominal_value"):
+                    value, uncertainty = float(magnitude.nominal_value), float(magnitude.std_dev)
+                else:
+                    value, uncertainty = float(magnitude), None
+                uncertain_serializable[key] = {"value": value, "uncertainty": uncertainty, "unit": format(q.units, "~")}
+            data["uncertain_statistics"] = uncertain_serializable
 
         # Add regions
         if self.regions:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -6,12 +6,13 @@ from oscilloscope waveform data.
 """
 
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from scipy import signal as scipy_signal
 from scipy.fft import fft, fftfreq, irfft, rfft
 
+from scpi_control.exceptions import InvalidParameterError
 from scpi_control.report_generator.models.report_data import WaveformData, WaveformRegion
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,32 @@ _MIN_MEASURABLE_NOISE_RATIO = 1e-9
 # fraction of the spectrum, too little signal-free spectrum remains to estimate
 # noise, so _estimate_noise returns None rather than a fabricated near-zero value.
 _MAX_NOTCHED_FRACTION = 0.9
+
+# Base units for compute_statistical_quantity's Quantity output. Scoped to
+# exactly the stat names format_stat_value (below) already recognizes and
+# groups the same way -- kept in this same file, next to that function, so
+# a future reader sees both. Not unified into one shared table: that would
+# touch format_stat_value's working, tested display logic for no behavior
+# change (see the design spec's Open risks).
+_STAT_BASE_UNITS = {
+    "vmax": "V",
+    "vmin": "V",
+    "vpp": "V",
+    "vmean": "V",
+    "vrms": "V",
+    "vamp": "V",
+    "dc_offset": "V",
+    "frequency": "Hz",
+    "period": "s",
+    "rise_time": "s",
+    "fall_time": "s",
+    "pulse_width": "s",
+    "jitter": "s",
+    "duty_cycle": "percent",
+    "overshoot": "percent",
+    "undershoot": "percent",
+    "top_flatness": "percent",
+}
 
 
 class SignalType:
@@ -364,6 +391,46 @@ class WaveformAnalyzer:
                 "undershoot": None,
                 "jitter": None,
             }
+
+    @staticmethod
+    def compute_statistical_quantity(waveforms: List[WaveformData], stat_name: str) -> "Quantity":  # noqa: F821
+        """Mean +/- sample stddev of one named statistic across N repeated captures.
+
+        Each waveform must already have `.statistics` populated (call
+        `.analyze()` on each first). Pure function of its arguments -- does
+        not know or care whether the waveforms came from batch_capture,
+        a manual loop, or files loaded from disk.
+
+        Args:
+            waveforms: At least 2 repeated captures of (nominally) the same
+                signal.
+            stat_name: A key already present in every waveform's
+                `.statistics`, and a key in `_STAT_BASE_UNITS`.
+
+        Returns:
+            A Quantity whose magnitude is an `uncertainties.ufloat(mean, stddev)`,
+            in `stat_name`'s base unit.
+
+        Raises:
+            InvalidParameterError: Fewer than 2 waveforms, an unrecognized
+                `stat_name`, or a waveform missing that statistic.
+        """
+        from scpi_control.quantities import quantity  # local: keeps `uncertainty` optional
+
+        if len(waveforms) < 2:
+            raise InvalidParameterError(f"compute_statistical_quantity needs at least 2 waveforms to measure a spread, got {len(waveforms)}")
+        if stat_name not in _STAT_BASE_UNITS:
+            raise InvalidParameterError(f"Unknown statistic {stat_name!r}; no base unit is registered for it. Known statistics: {sorted(_STAT_BASE_UNITS)}")
+
+        values = []
+        for index, waveform in enumerate(waveforms):
+            if not waveform.statistics or waveform.statistics.get(stat_name) is None:
+                raise InvalidParameterError(f"Waveform {index} has no {stat_name!r} statistic. Call .analyze() on every waveform first.")
+            values.append(float(waveform.statistics[stat_name]))
+
+        mean = float(np.mean(values))
+        stddev = float(np.std(values, ddof=1))
+        return quantity(mean, _STAT_BASE_UNITS[stat_name], uncertainty=stddev)
 
     @staticmethod
     def _estimate_noise(waveform: WaveformData) -> Optional[float]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,24 @@ import pytest
 from scpi_control.report_generator.models.report_data import WaveformData
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-llm",
+        action="store_true",
+        default=False,
+        help="run tests marked 'llm' (exercise the optional LLM-analysis feature; skipped by default since most installs don't use it)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-llm"):
+        return
+    skip_llm = pytest.mark.skip(reason="LLM tests skipped by default -- pass --run-llm to include them")
+    for item in items:
+        if "llm" in item.keywords:
+            item.add_marker(skip_llm)
+
+
 def _event_loop_state():
     """(holder, loop, set_called) for this thread's current-event-loop state.
 

--- a/tests/test_daq_llm.py
+++ b/tests/test_daq_llm.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
 from scpi_control.report_generator.llm.context_builder import ContextBuilder
@@ -17,6 +18,8 @@ from scpi_control.report_generator.llm.daq_analyzer import DAQAnalyzer
 from scpi_control.report_generator.llm.daq_context_builder import DAQContextBuilder
 from scpi_control.report_generator.llm.daq_prompts import get_daq_system_prompt
 from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
+
+pytestmark = pytest.mark.llm
 
 _KEYS = ["expert", "trends", "thresholds", "summary", "chat"]
 

--- a/tests/test_instrument_specs.py
+++ b/tests/test_instrument_specs.py
@@ -1,0 +1,46 @@
+"""Pluggable instrument accuracy-spec registry.
+
+Ships with zero populated entries by design (see the design spec's
+Non-goals -- only programming guides, not datasheets, are in this repo, and
+this project does not fabricate accuracy numbers). This tests the plumbing:
+register, look up, and the "no spec on file" honest-None path.
+
+Pure-CPU. No pint/uncertainties dependency -- this module doesn't need them.
+"""
+
+import pytest
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.instrument_specs import AccuracySpec, lookup_accuracy_spec, register_accuracy_spec
+
+
+def test_lookup_with_no_registered_spec_returns_none():
+    assert lookup_accuracy_spec("Nonexistent Co", "Model X", "voltage") is None
+
+
+def test_register_and_look_up_round_trip():
+    spec = AccuracySpec(
+        formula=lambda reading, full_scale: abs(reading) * 0.03 + full_scale * 0.005,
+        source="Test Datasheet p.1, vertical accuracy table",
+    )
+    register_accuracy_spec("Siglent", "SDS824X HD", "voltage", spec)
+    try:
+        found = lookup_accuracy_spec("Siglent", "SDS824X HD", "voltage")
+        assert found is spec
+        assert found.formula(1.0, 10.0) == pytest.approx(0.08)
+    finally:
+        # Test isolation: the registry is module-level global state.
+        from scpi_control import instrument_specs
+
+        instrument_specs._REGISTRY.pop(("Siglent", "SDS824X HD", "voltage"), None)
+
+
+def test_accuracy_spec_requires_a_source():
+    with pytest.raises(TypeError):
+        AccuracySpec(formula=lambda reading, full_scale: 0.0)  # missing required `source`
+
+
+def test_register_rejects_an_empty_source():
+    spec = AccuracySpec(formula=lambda reading, full_scale: 0.0, source="")
+    with pytest.raises(InvalidParameterError):
+        register_accuracy_spec("Siglent", "SDS824X HD", "voltage", spec)

--- a/tests/test_llm_tool_loop.py
+++ b/tests/test_llm_tool_loop.py
@@ -6,9 +6,13 @@ docstring for why nothing else works for the SDK path.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
 
 from tests.conftest import ollama_sdk
+
+pytestmark = pytest.mark.llm
 
 
 def reply(content=None, tool_calls=None):

--- a/tests/test_llm_tool_support.py
+++ b/tests/test_llm_tool_support.py
@@ -4,9 +4,13 @@ READ THE FIXTURE'S DOCSTRING (tests/conftest.py:ollama_sdk). LLMClient.__init__
 probes a live Ollama server, and there is one running on the dev machine.
 """
 
+import pytest
+
 from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
 
 from tests.conftest import ollama_sdk
+
+pytestmark = pytest.mark.llm
 
 
 def ollama_config(model="llama3.2", timeout=60):

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -1,0 +1,47 @@
+"""value + unit (+ optional uncertainty), via pint + uncertainties.
+
+Pure-CPU, no instrument. Requires the `uncertainty` extra -- skipped cleanly
+if it isn't installed, matching this repo's other optional-dependency tests.
+"""
+
+import pytest
+
+pint = pytest.importorskip("pint")
+pytest.importorskip("uncertainties")
+
+from scpi_control.quantities import format_quantity, quantity
+
+
+def test_quantity_plain_value_has_a_float_magnitude():
+    q = quantity(1.234, "V")
+    assert q.magnitude == 1.234
+    assert str(q.units) == "volt"
+
+
+def test_quantity_with_uncertainty_carries_a_ufloat_magnitude():
+    q = quantity(1.234, "V", uncertainty=0.012)
+    assert q.magnitude.nominal_value == pytest.approx(1.234)
+    assert q.magnitude.std_dev == pytest.approx(0.012)
+
+
+def test_mismatched_dimension_addition_raises():
+    volts = quantity(1.0, "V")
+    seconds = quantity(1.0, "s")
+    with pytest.raises(pint.errors.DimensionalityError):
+        volts + seconds
+
+
+def test_format_quantity_without_uncertainty_uses_compact_si_prefix():
+    assert format_quantity(quantity(0.012, "V")) == "12 mV"
+
+
+def test_format_quantity_with_uncertainty():
+    assert format_quantity(quantity(1.234, "V", uncertainty=0.012)) == "1.23 ± 0.012 V"
+
+
+def test_format_quantity_compacts_a_small_time_with_uncertainty():
+    assert format_quantity(quantity(12.34e-9, "s", uncertainty=0.12e-9)) == "12.3 ± 0.12 ns"
+
+
+def test_format_quantity_percent_unit():
+    assert format_quantity(quantity(50.0, "percent")) == "50 %"

--- a/tests/test_report_data_uncertain_statistics.py
+++ b/tests/test_report_data_uncertain_statistics.py
@@ -1,0 +1,44 @@
+"""WaveformData.uncertain_statistics: additive storage for Quantity-valued
+stats, alongside the existing plain-float .statistics dict.
+
+Requires the `uncertainty` extra (to build a real Quantity to attach).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pint")
+pytest.importorskip("uncertainties")
+
+from scpi_control.quantities import quantity
+from scpi_control.report_generator.models.report_data import WaveformData
+
+
+def _waveform():
+    n, rate = 100, 1e6
+    t = np.arange(n) / rate
+    v = np.zeros(n)
+    return WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+
+
+def test_uncertain_statistics_defaults_to_none():
+    assert _waveform().uncertain_statistics is None
+
+
+def test_to_dict_omits_uncertain_statistics_when_unset():
+    data = _waveform().to_dict()
+    assert "uncertain_statistics" not in data
+
+
+def test_to_dict_serializes_a_quantity_with_uncertainty():
+    wf = _waveform()
+    wf.uncertain_statistics = {"vpp": quantity(1.234, "V", uncertainty=0.012)}
+    data = wf.to_dict()
+    assert data["uncertain_statistics"] == {"vpp": {"value": pytest.approx(1.234), "uncertainty": pytest.approx(0.012), "unit": "V"}}
+
+
+def test_to_dict_serializes_a_quantity_with_no_uncertainty():
+    wf = _waveform()
+    wf.uncertain_statistics = {"frequency": quantity(1000.0, "Hz")}
+    data = wf.to_dict()
+    assert data["uncertain_statistics"] == {"frequency": {"value": pytest.approx(1000.0), "uncertainty": None, "unit": "Hz"}}

--- a/tests/test_report_llm_client.py
+++ b/tests/test_report_llm_client.py
@@ -6,6 +6,8 @@ import pytest
 
 from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
 
+pytestmark = pytest.mark.llm
+
 
 def test_create_daq_analyzer_constructs():
     """It raised TypeError on every call: LLMClient takes a config, not kwargs.

--- a/tests/test_report_llm_prompts.py
+++ b/tests/test_report_llm_prompts.py
@@ -5,6 +5,8 @@ import pytest
 
 from scpi_control.report_generator.llm.prompts import _GROUNDING, get_system_prompt
 
+pytestmark = pytest.mark.llm
+
 ALL_PROMPTS = ["expert", "summary", "analysis", "interpretation", "chat", "chat_tools"]
 
 

--- a/tests/test_report_waveform_model.py
+++ b/tests/test_report_waveform_model.py
@@ -102,6 +102,7 @@ def test_field_order_is_the_library_core_then_report_concerns():
         "signal_type",
         "signal_type_confidence",
         "statistics",
+        "uncertain_statistics",
         "regions",
         "annotations",
         "caption",

--- a/tests/test_uncertain_statistics_rendering.py
+++ b/tests/test_uncertain_statistics_rendering.py
@@ -62,3 +62,36 @@ def test_pdf_renders_plus_minus_when_vpp_has_uncertainty():
     table = PDFReportGenerator()._generate_statistics_table(wf)
     rows = {row[0]: row[1] for row in table._cellvalues}
     assert rows["Vpp:"] == "4 ± 0.05 V"
+
+
+def _unanalyzed_waveform():
+    """A WaveformData that never had .analyze() called, so .statistics is
+    still None -- the representative-waveform pattern the design spec
+    documents for attaching uncertain_statistics (see docs/superpowers/specs/
+    2026-08-27-measurement-uncertainty-design.md)."""
+    n, rate = 10_000, 1e6
+    t = np.arange(n) / rate
+    v = 2.0 * np.sin(2 * np.pi * 10_000 * t)
+    wf = WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+    assert wf.statistics is None
+    return wf
+
+
+def test_markdown_renders_uncertain_stat_even_when_waveform_never_analyzed():
+    wf = _unanalyzed_waveform()
+    wf.uncertain_statistics = {"vpp": quantity(4.0, "V", uncertainty=0.05)}
+    text = MarkdownReportGenerator()._generate_waveform_info(wf, Path("."), "CH1")
+    assert "**Signal Statistics:**" in text
+    assert "| VPP | 4 ± 0.05 V |" in text
+
+
+def test_markdown_and_pdf_agree_when_waveform_never_analyzed():
+    wf = _unanalyzed_waveform()
+    wf.uncertain_statistics = {"vpp": quantity(4.0, "V", uncertainty=0.05)}
+
+    md_text = MarkdownReportGenerator()._generate_waveform_info(wf, Path("."), "CH1")
+    pdf_table = PDFReportGenerator()._generate_statistics_table(wf)
+    pdf_rows = {row[0]: row[1] for row in pdf_table._cellvalues}
+
+    assert "| VPP | 4 ± 0.05 V |" in md_text
+    assert pdf_rows["Vpp:"] == "4 ± 0.05 V"

--- a/tests/test_uncertain_statistics_rendering.py
+++ b/tests/test_uncertain_statistics_rendering.py
@@ -13,6 +13,7 @@ import pytest
 
 pytest.importorskip("pint")
 pytest.importorskip("uncertainties")
+pytest.importorskip("reportlab")
 
 from scpi_control.quantities import quantity
 from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator

--- a/tests/test_uncertain_statistics_rendering.py
+++ b/tests/test_uncertain_statistics_rendering.py
@@ -1,0 +1,64 @@
+"""Both report generators prefer WaveformData.uncertain_statistics over the
+plain .statistics value when a stat has an uncertain entry -- one extra
+conditional per generator, no new table/column. Byte-identical output when
+uncertain_statistics is unset (the common case today).
+
+Requires the `uncertainty` extra (to build a real Quantity to attach).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pint")
+pytest.importorskip("uncertainties")
+
+from scpi_control.quantities import quantity
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+from scpi_control.report_generator.models.report_data import WaveformData
+
+
+def _analyzed_waveform():
+    """A real sine so .analyze() populates vpp/frequency/etc, matching how
+    this field is actually populated in practice (not a stub statistics dict)."""
+    n, rate = 10_000, 1e6
+    t = np.arange(n) / rate
+    v = 2.0 * np.sin(2 * np.pi * 10_000 * t)
+    wf = WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+    wf.analyze()
+    return wf
+
+
+def test_markdown_uses_plain_formatting_when_uncertain_statistics_unset():
+    wf = _analyzed_waveform()
+    baseline = MarkdownReportGenerator()._generate_waveform_info(wf, Path("."), "CH1")
+
+    wf2 = _analyzed_waveform()  # separate instance, same signal -> same analysis
+    with_field_but_empty = MarkdownReportGenerator()._generate_waveform_info(wf2, Path("."), "CH1")
+    assert with_field_but_empty == baseline
+    assert "±" not in baseline
+
+
+def test_markdown_renders_plus_minus_when_vpp_has_uncertainty():
+    wf = _analyzed_waveform()
+    wf.uncertain_statistics = {"vpp": quantity(4.0, "V", uncertainty=0.05)}
+    text = MarkdownReportGenerator()._generate_waveform_info(wf, Path("."), "CH1")
+    assert "| VPP | 4 ± 0.05 V |" in text
+
+
+def test_pdf_uses_plain_formatting_when_uncertain_statistics_unset():
+    wf = _analyzed_waveform()
+    baseline_table = PDFReportGenerator()._generate_statistics_table(wf)
+    wf2 = _analyzed_waveform()
+    same_table = PDFReportGenerator()._generate_statistics_table(wf2)
+    assert baseline_table._cellvalues == same_table._cellvalues
+
+
+def test_pdf_renders_plus_minus_when_vpp_has_uncertainty():
+    wf = _analyzed_waveform()
+    wf.uncertain_statistics = {"vpp": quantity(4.0, "V", uncertainty=0.05)}
+    table = PDFReportGenerator()._generate_statistics_table(wf)
+    rows = {row[0]: row[1] for row in table._cellvalues}
+    assert rows["Vpp:"] == "4 ± 0.05 V"

--- a/tests/test_waveform_analyzer_uncertainty.py
+++ b/tests/test_waveform_analyzer_uncertainty.py
@@ -1,0 +1,62 @@
+"""WaveformAnalyzer.compute_statistical_quantity: mean +/- stddev across N
+repeated captures of the same measurement, as a unit-aware Quantity.
+
+Pure-CPU, no instrument. Requires the `uncertainty` extra.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pint")
+pytest.importorskip("uncertainties")
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def _stub_waveform(stat_value):
+    """A minimal WaveformData with .statistics pre-populated -- this test
+    exercises the aggregation, not .analyze() itself."""
+    n, rate = 100, 1e6
+    t = np.arange(n) / rate
+    v = np.zeros(n)
+    wf = WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)
+    wf.statistics = {"vpp": stat_value}
+    return wf
+
+
+def test_mean_and_stddev_match_a_hand_computed_example():
+    # values = [2.0, 4.0]: mean 3.0, sample stddev (ddof=1) sqrt(2) = 1.4142135623730951
+    waveforms = [_stub_waveform(2.0), _stub_waveform(4.0)]
+    q = WaveformAnalyzer.compute_statistical_quantity(waveforms, "vpp")
+    assert q.magnitude.nominal_value == pytest.approx(3.0)
+    assert q.magnitude.std_dev == pytest.approx(1.4142135623730951)
+    assert str(q.units) == "volt"
+
+
+def test_four_repeated_captures():
+    # values = [1,2,3,4]: mean 2.5, sample stddev (ddof=1) = 1.2909944487358056
+    waveforms = [_stub_waveform(v) for v in (1.0, 2.0, 3.0, 4.0)]
+    q = WaveformAnalyzer.compute_statistical_quantity(waveforms, "vpp")
+    assert q.magnitude.nominal_value == pytest.approx(2.5)
+    assert q.magnitude.std_dev == pytest.approx(1.2909944487358056)
+
+
+def test_fewer_than_two_waveforms_raises():
+    with pytest.raises(InvalidParameterError, match="at least 2"):
+        WaveformAnalyzer.compute_statistical_quantity([_stub_waveform(1.0)], "vpp")
+
+
+def test_unknown_stat_name_raises():
+    waveforms = [_stub_waveform(1.0), _stub_waveform(2.0)]
+    with pytest.raises(InvalidParameterError, match="Unknown statistic"):
+        WaveformAnalyzer.compute_statistical_quantity(waveforms, "not_a_real_stat")
+
+
+def test_missing_stat_on_one_waveform_raises():
+    wf1 = _stub_waveform(1.0)
+    wf2 = _stub_waveform(2.0)
+    wf2.statistics = {}  # 'vpp' never computed for this one
+    with pytest.raises(InvalidParameterError, match="no 'vpp' statistic"):
+        WaveformAnalyzer.compute_statistical_quantity([wf1, wf2], "vpp")


### PR DESCRIPTION
## Summary

- Adds unit-aware, uncertainty-carrying `Quantity` values (`scpi_control.quantities`, wrapping `pint`/`uncertainties`) behind a new opt-in `uncertainty` extra — `pip install "SCPI-Instrument-Control[uncertainty]"`. No existing method's return type changes.
- `WaveformAnalyzer.compute_statistical_quantity` computes mean ± sample standard deviation (ddof=1) across N repeated captures of the same measurement (e.g. `vpp` across several `batch_capture` triggers), returned as a `Quantity`.
- `WaveformData` gets a new additive `uncertain_statistics` field; both the PDF and Markdown report generators render it as `"1.23 ± 0.012 V"` in place of the plain value, with no other change to existing reports.
- Adds a pluggable per-instrument accuracy-spec registry (`scpi_control.instrument_specs`) — real structure, zero pre-populated entries, since only programming guides (not datasheets with accuracy tables) are in this repo. Real formulas land later from real datasheet citations.

## Notes for reviewers

- Built from `docs/superpowers/plans/2026-08-27-measurement-uncertainty.md`, 7 tasks, each individually reviewed clean, plus a final whole-branch review across the full diff.
- The whole-branch review caught one real cross-cutting bug that no single task's isolated tests could see: the Markdown generator only consulted `uncertain_statistics` for a row's *value*, not for whether to *show* the row at all (it gated on the plain `.statistics` dict). A waveform with `uncertain_statistics` set but never `.analyze()`'d — the representative-waveform pattern this feature's own design doc describes — got a PDF report showing the uncertain value and a Markdown report silently missing the entire "Signal Statistics" section. Fixed, with a regression test asserting Markdown/PDF agreement on that exact case.
- Two Minor issues were found, deliberately parked (both confirmed still fine to defer, not load-bearing for this PR):
  - `format_quantity` crashes on a logarithmic/non-multiplicative unit like `dB` when the value carries uncertainty — currently unreachable, since nothing this branch ships can produce a dB-unit `Quantity`.
  - The PDF "unset" regression test is a self-comparison (plain vs. plain) rather than an exact-row-set assertion, so it wouldn't independently catch a future dropped/mislabeled row.

## Test plan

- [x] `pytest -m "not slow" -n 8` (LLM-specific test files excluded this session per explicit ask, not run) — 2899 passed, 19 skipped, clean
- [x] `black --check --line-length 200 scpi_control/ examples/` — clean
- [x] `flake8 scpi_control/ --count --select=E9,F63,F7,F82` — clean
- [x] New/changed test files run directly and individually pass: `test_quantities.py`, `test_instrument_specs.py`, `test_waveform_analyzer_uncertainty.py`, `test_report_data_uncertain_statistics.py`, `test_uncertain_statistics_rendering.py`, `test_report_waveform_model.py`
- [ ] Run the 5 LLM-specific test files (`test_daq_llm.py`, `test_report_llm_prompts.py`, `test_llm_tool_loop.py`, `test_llm_tool_support.py`, `test_report_llm_client.py`) before treating this as a fully complete whole-suite milestone verification — unrelated to this change but not exercised this session
