### PR TITLE
fix(report): AI-staleness gap, escaping-mode typing, test hardening

### DIFF
--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -13,7 +13,7 @@ import logging
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Literal, Optional, Tuple
 
 try:
     from reportlab.lib import colors
@@ -404,7 +404,7 @@ class PDFReportGenerator(BaseReportGenerator):
 
         return escape(text or "")
 
-    def _para(self, text: str, style, mode: str = "markdown") -> Paragraph:
+    def _para(self, text: str, style, mode: Literal["markdown", "literal", "preformatted"] = "markdown") -> Paragraph:
         """The only place a Paragraph flowable is constructed in this file.
 
         mode="markdown": run through _markdown_to_reportlab (bold/italic/

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -331,7 +331,7 @@ class MainWindow(QMainWindow):
                 # so a later file in the batch failing to load (or
                 # load_annotations_into raising) still leaves stale AI
                 # content invalidated rather than surviving the exception.
-                self.ai_analysis_panel._clear_results()
+                self.ai_analysis_panel.invalidate_results()
 
             applied = load_annotations_into(self.waveforms)
             if applied:
@@ -353,6 +353,8 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "No waveform selected", "Select a waveform in the list to annotate it.")
             return
         AnnotationDialog(self.waveforms[row], self).exec()
+        # Annotation/caption edits can make existing AI narrative stale (audit H27).
+        self.ai_analysis_panel.invalidate_results()
 
     def _import_images(self):
         """Import image files."""
@@ -381,7 +383,7 @@ class MainWindow(QMainWindow):
             self.waveform_list.clear()
             # Any AI-generated content described the data that just left --
             # it no longer corresponds to anything (audit H27).
-            self.ai_analysis_panel._clear_results()
+            self.ai_analysis_panel.invalidate_results()
             self.statusBar().showMessage("Data cleared")
 
     def _configure_llm(self):

--- a/scpi_control/report_generator/widgets/ai_analysis_panel.py
+++ b/scpi_control/report_generator/widgets/ai_analysis_panel.py
@@ -568,6 +568,10 @@ class AIAnalysisPanel(QWidget):
         self.clear_button.setEnabled(False)
         self._update_status_display()
 
+    def invalidate_results(self) -> None:
+        """Public entry point for external callers (e.g. MainWindow) to invalidate stale AI content (audit H27)."""
+        self._clear_results()
+
     def get_generated_content(self) -> Dict:
         """
         Get generated AI content.

--- a/tests/test_main_window_ai_staleness.py
+++ b/tests/test_main_window_ai_staleness.py
@@ -10,6 +10,7 @@ tests/test_main_window_annotations.py.
 
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -119,4 +120,25 @@ def test_import_waveforms_partial_failure_still_invalidates_ai_content(window, m
     window._import_waveforms()
 
     assert len(window.waveforms) == 1  # file1's waveform was kept
+    assert not window.ai_analysis_panel.has_generated_content()
+
+
+def test_annotating_a_waveform_invalidates_ai_content(window, monkeypatch):
+    """Annotating a waveform mutates its .annotations/.caption in place
+    (AnnotationDialog), so any previously-generated AI content could
+    describe a state that no longer matches -- same staleness class as
+    import/clear (AUDIT.md H27), just for a third trigger."""
+    waveform = _make_waveform("C1", Path("capture.csv"))
+    window.waveforms.append(waveform)
+    window.waveform_list.addItem(f"{waveform.channel} - {waveform.source_file.name}")
+    window.waveform_list.setCurrentRow(0)
+
+    _seed_ai_content(window)
+
+    dialog_instance = MagicMock()
+    dialog_spy = MagicMock(return_value=dialog_instance)
+    monkeypatch.setattr(mw_module, "AnnotationDialog", dialog_spy)
+
+    window._on_annotate_waveform()
+
     assert not window.ai_analysis_panel.has_generated_content()

--- a/tests/test_pdf_generator_escaping.py
+++ b/tests/test_pdf_generator_escaping.py
@@ -14,6 +14,7 @@ import pytest
 pytest.importorskip("reportlab")
 
 from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+from scpi_control.report_generator.generators import pdf_generator as pdf_generator_module  # noqa: E402
 from scpi_control.report_generator.models.report_data import (  # noqa: E402
     ReportMetadata,
     TestReport,
@@ -122,6 +123,6 @@ def test_paragraph_construction_only_happens_through__para():
     forgetting to escape. Exactly one occurrence of the literal substring
     is expected -- the `return Paragraph(escaped, style)` inside _para
     itself."""
-    src = Path("scpi_control/report_generator/generators/pdf_generator.py").read_text(encoding="utf-8")
+    src = Path(pdf_generator_module.__file__).read_text(encoding="utf-8")
     count = src.count("Paragraph(")
     assert count == 1, f"expected exactly 1 direct Paragraph(...) call (inside _para), found {count}"

--- a/tests/test_uncertain_statistics_rendering.py
+++ b/tests/test_uncertain_statistics_rendering.py
@@ -33,6 +33,9 @@ def _analyzed_waveform():
 
 
 def test_markdown_uses_plain_formatting_when_uncertain_statistics_unset():
+    """Checks determinism (two runs match) AND specific known-correct content
+    (real stat rows for the 10 kHz/4 Vpp sine, verified against actual
+    generator output rather than assumed)."""
     wf = _analyzed_waveform()
     baseline = MarkdownReportGenerator()._generate_waveform_info(wf, Path("."), "CH1")
 
@@ -40,6 +43,14 @@ def test_markdown_uses_plain_formatting_when_uncertain_statistics_unset():
     with_field_but_empty = MarkdownReportGenerator()._generate_waveform_info(wf2, Path("."), "CH1")
     assert with_field_but_empty == baseline
     assert "±" not in baseline
+
+    assert "**Signal Statistics:**" in baseline
+    assert "| VMAX | 2.000 V |" in baseline
+    assert "| VMIN | -2.000 V |" in baseline
+    assert "| VPP | 4.000 V |" in baseline
+    assert "| VRMS | 1.414 V |" in baseline
+    assert "| Frequency | 10.000 kHz |" in baseline
+    assert "| Period | 100.000 µs |" in baseline
 
 
 def test_markdown_renders_plus_minus_when_vpp_has_uncertainty():
@@ -50,11 +61,22 @@ def test_markdown_renders_plus_minus_when_vpp_has_uncertainty():
 
 
 def test_pdf_uses_plain_formatting_when_uncertain_statistics_unset():
+    """Checks determinism (two runs match) AND specific known-correct content
+    (real stat rows for the 10 kHz/4 Vpp sine, verified against actual
+    generator output rather than assumed)."""
     wf = _analyzed_waveform()
     baseline_table = PDFReportGenerator()._generate_statistics_table(wf)
     wf2 = _analyzed_waveform()
     same_table = PDFReportGenerator()._generate_statistics_table(wf2)
     assert baseline_table._cellvalues == same_table._cellvalues
+
+    rows = {row[0]: row[1] for row in baseline_table._cellvalues}
+    assert rows["Vmax:"] == "2.000 V"
+    assert rows["Vmin:"] == "-2.000 V"
+    assert rows["Vpp:"] == "4.000 V"
+    assert rows["Vrms:"] == "1.414 V"
+    assert rows["Frequency:"] == "10.000 kHz"
+    assert rows["Period:"] == "100.000 µs"
 
 
 def test_pdf_renders_plus_minus_when_vpp_has_uncertainty():


### PR DESCRIPTION
## Summary

Four small, independent cleanup items left over from earlier audit rounds — no user-facing behavior change beyond one real bug fix:

- **Real fix:** `AIAnalysisPanel` gets a public `invalidate_results()` entry point. `MainWindow` was already calling the private `_clear_results()` cross-object from two sites (audit H27's import/clear invalidation); this closes that API smell *and* closes a real gap — `_on_annotate_waveform()` never invalidated stale AI-generated content after the annotation dialog closed, even though the dialog mutates the waveform's `.annotations`/`.caption` in place. Same staleness class H27 already covers for import/clear, just missing its third trigger. Regression test added.
- `_para`'s `mode` parameter (the H25 escaping-centralization point in the PDF generator) narrowed from `str` to `Literal["markdown", "literal", "preformatted"]` — a typo would previously fall through to the safe-but-wrong branch silently; now it's a type error. Pure annotation change.
- A structural regression test (`test_paragraph_construction_only_happens_through__para`) resolved its target source file via a CWD-relative path instead of the imported module's `__file__`, so it errored rather than failing meaningfully if pytest ever ran from outside the repo root. Fixed and verified from two different working directories.
- Two "unset" regression tests in `test_uncertain_statistics_rendering.py` only compared two generator runs against each other (self-comparison) rather than against known-correct output — a future change that silently dropped or mislabeled every stat row identically across both calls would still have passed. Added specific row/label assertions, verified against real generator output.

## Notes for reviewers

Each item was implemented by an independent subagent (disjoint file sets, no overlap), then all four were checked together in one consolidated review pass before this PR — verdict "Ready to commit: Yes", no Critical/Important findings. Two Minor notes from that review, both judged non-blocking:
- The strengthened tests are now coupled to `WaveformAnalyzer.format_stat_value`'s exact precision/unit-threshold formatting — intentional, since the whole point was to stop asserting only self-equality.
- No CHANGELOG entry, since none of these changes user-facing library behavior.

## Test plan

- [x] `pytest -m "not slow" -n 8` — 2900 passed, 60 skipped, clean
- [x] `black --check --line-length 200 scpi_control/ examples/` — clean
- [x] `flake8 scpi_control/ --count --select=E9,F63,F7,F82` — clean
- [x] Scoped GUI/PDF test run (PyQt6 + reportlab both installed here): `test_main_window_ai_staleness.py`, `test_main_window_annotations.py`, `test_gui_initialization.py`, `test_annotation_dialog.py`, `test_pdf_generator_escaping.py`, `test_uncertain_statistics_rendering.py`, plus several other PDF test files — 59 tests, all pass
