### PR TITLE
feat: signal timing jitter for mock synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   populated entries, since only programming guides (not datasheets with
   accuracy tables) are in this repo; real formulas are added later from
   real datasheet citations. No existing method's return type changed.
+- **Timing/period jitter for mock signal synthesis.** `SignalSpec` gains a new
+  `jitter_rms` field (seconds, default `0.0` = off) that injects period-to-period
+  timing jitter into synthesized signals -- the "random jitter" (RJ) definition
+  `WaveformAnalyzer._calculate_quality_stats` already computes as
+  `std(diff(edge_indices)) * dt`, previously unexercised because nothing in this
+  codebase could produce a signal with nonzero period jitter to measure. Applies
+  to `PERIODIC_KINDS` only (sine, square, triangle, ramp, multitone,
+  exponential, pulse); `dc`/`noise` have no cycle structure and `chirp` has no
+  stable period, so `jitter_rms` is a no-op on those three. Each cycle boundary
+  draws an independent Gaussian time-shift, and every sample's shift is the
+  linear interpolation between the two boundaries straddling it -- a continuous
+  time warp, not a per-cycle hard step -- so an enabled `ringing_frequency`
+  keys on the actual jittered edge rather than the nominal one, with no
+  special-casing needed. What comes back through `WaveformAnalyzer` depends on
+  where a kind's measured edge sits within its cycle: for `sine`, `square`,
+  `multitone`, and `pulse`, whose measured edge sits at the cycle boundary,
+  measured jitter matches the injected `jitter_rms` almost exactly (ratio
+  0.94-1.08 across trials); for `triangle` and `ramp`, whose measured edge
+  sits mid-cycle, measured jitter is a smaller, stable, documented fraction of
+  the setting (~0.66-0.68 for triangle, ~0.50-0.52 for ramp -- see
+  `SignalSpec.jitter_rms`'s docstring and
+  `docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md` for the
+  full calibration table and derivation). **Known limitation:** `stream()`
+  bumps `spec.seed` by chunk index on every call (existing, deliberate
+  behavior), so a cycle that happens to straddle a `stream()` chunk boundary
+  gets two different jitter draws from the two chunk calls that observe it --
+  a small, bounded discontinuity affecting at most that one cycle. Single
+  `synthesize()`/`make_waveform()` calls -- mock oscilloscope waveform
+  queries, and essentially all test/example usage -- are completely
+  unaffected; only a long-running `stream()` consumer would ever see it, and
+  only at chunk boundaries. True stream-continuity for jitter is an explicit
+  next feature, not part of this one.
 
 ### Fixed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -23,6 +23,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   populated entries, since only programming guides (not datasheets with
   accuracy tables) are in this repo; real formulas are added later from
   real datasheet citations. No existing method's return type changed.
+- **Timing/period jitter for mock signal synthesis.** `SignalSpec` gains a new
+  `jitter_rms` field (seconds, default `0.0` = off) that injects period-to-period
+  timing jitter into synthesized signals -- the "random jitter" (RJ) definition
+  `WaveformAnalyzer._calculate_quality_stats` already computes as
+  `std(diff(edge_indices)) * dt`, previously unexercised because nothing in this
+  codebase could produce a signal with nonzero period jitter to measure. Applies
+  to `PERIODIC_KINDS` only (sine, square, triangle, ramp, multitone,
+  exponential, pulse); `dc`/`noise` have no cycle structure and `chirp` has no
+  stable period, so `jitter_rms` is a no-op on those three. Each cycle boundary
+  draws an independent Gaussian time-shift, and every sample's shift is the
+  linear interpolation between the two boundaries straddling it -- a continuous
+  time warp, not a per-cycle hard step -- so an enabled `ringing_frequency`
+  keys on the actual jittered edge rather than the nominal one, with no
+  special-casing needed. What comes back through `WaveformAnalyzer` depends on
+  where a kind's measured edge sits within its cycle: for `sine`, `square`,
+  `multitone`, and `pulse`, whose measured edge sits at the cycle boundary,
+  measured jitter matches the injected `jitter_rms` almost exactly (ratio
+  0.94-1.08 across trials); for `triangle` and `ramp`, whose measured edge
+  sits mid-cycle, measured jitter is a smaller, stable, documented fraction of
+  the setting (~0.66-0.68 for triangle, ~0.50-0.52 for ramp -- see
+  `SignalSpec.jitter_rms`'s docstring and
+  `docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md` for the
+  full calibration table and derivation). **Known limitation:** `stream()`
+  bumps `spec.seed` by chunk index on every call (existing, deliberate
+  behavior), so a cycle that happens to straddle a `stream()` chunk boundary
+  gets two different jitter draws from the two chunk calls that observe it --
+  a small, bounded discontinuity affecting at most that one cycle. Single
+  `synthesize()`/`make_waveform()` calls -- mock oscilloscope waveform
+  queries, and essentially all test/example usage -- are completely
+  unaffected; only a long-running `stream()` consumer would ever see it, and
+  only at chunk boundaries. True stream-continuity for jitter is an explicit
+  next feature, not part of this one.
 
 ### Fixed
 

--- a/examples/synthetic_signals.py
+++ b/examples/synthetic_signals.py
@@ -15,8 +15,10 @@ stats, (2) opens a mock oscilloscope session, acquires, then changes TDIV and
 VDIV over SCPI to show the capture's length and clipping respond, (3) saves
 one synthesized capture and reloads it with load_waveform() to show the chain
 composes, (4) synthesizes a multitone and compares its measured THD to the
-analytically expected value, and (5) synthesizes a chirp and measures its
-start/end frequency from zero crossings.
+analytically expected value, (5) synthesizes a chirp and measures its
+start/end frequency from zero crossings, and (6) synthesizes a sine with
+known timing jitter and compares its measured period jitter to the injected
+value.
 
 Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
 a mock connection, no instrument needed.
@@ -29,6 +31,7 @@ import numpy as np
 from scpi_control.analysis import FFTAnalyzer
 from scpi_control.connection import MockConnection
 from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 from scpi_control.signal_synth import SignalSpec, make_waveform
 from scpi_control.waveform_io import load_waveform
 
@@ -160,12 +163,36 @@ def demo_chirp() -> None:
     print(f"chirp: measured start = {start_freq:.1f} Hz  measured end = {end_freq:.1f} Hz")
 
 
+def demo_jitter() -> None:
+    """Synthesize a jittered sine and compare its measured period jitter to
+    the injected jitter_rms, via the same WaveformAnalyzer call path the
+    tests use.
+
+    jitter_rms is per-kind-calibrated (see
+    docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md's Model
+    section): a kind whose measured rising edge sits exactly at a cycle
+    boundary -- sine, square, multitone, pulse -- measures close to the
+    nominal value, as demonstrated here. triangle/ramp measure a smaller,
+    but stable and documented, fraction of it (~0.66x and ~0.5x
+    respectively) because their measured edge sits mid-cycle, where
+    neighboring cycles' jitter draws partially cancel.
+    """
+    print()
+    print("=== Part 6: jitter -- measured vs. injected period jitter (sine) ===")
+    jitter_rms = 3e-6  # seconds
+    spec = SignalSpec(kind="sine", frequency=10_000.0, amplitude=1.0, jitter_rms=jitter_rms, seed=21)
+    waveform = make_waveform(spec, sample_rate=1_000_000.0, n_points=50_000)
+    measured_jitter = WaveformAnalyzer.calculate_quality_stats(waveform)["jitter"]
+    print(f"jitter: injected jitter_rms = {jitter_rms * 1e6:.2f} us  " f"measured = {measured_jitter * 1e6:.2f} us")
+
+
 def main() -> None:
     demo_make_waveform()
     demo_mock_session()
     demo_reload()
     demo_multitone()
     demo_chirp()
+    demo_jitter()
 
 
 if __name__ == "__main__":

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -65,6 +65,27 @@ class SignalSpec:
             harmonic. `amplitude` is the FUNDAMENTAL's amplitude, so the peak
             of the sum is higher; that is deliberate, since normalizing would
             make the THD of a multitone depend on its harmonic set.
+        jitter_rms: Std-dev of period-to-period timing jitter, in seconds (0 =
+            off). PERIODIC_KINDS only (sine, square, triangle, ramp,
+            multitone, exponential, pulse): "dc"/"noise" have no cycle
+            structure and "chirp" has no stable period, so on those three
+            kinds this field is a no-op rather than an error. Each cycle gets
+            its own independent Gaussian time-shift and the WHOLE cycle --
+            not just its edge -- moves by it, so an enabled `ringing_frequency`
+            keys on the actual jittered edge, not the nominal one, with no
+            special-casing needed. Calibrated so `jitter_rms` IS the value a
+            caller gets back from measuring the output: the internal per-cycle
+            draw uses sigma = jitter_rms / sqrt(2), because a measured period
+            is the difference of two independent per-cycle deltas
+            (period[n] = T + delta[n+1] - delta[n]), so
+            std(period) = sigma * sqrt(2). See
+            docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md
+            for the full derivation. KNOWN LIMITATION: stream() bumps
+            spec.seed per chunk, so a cycle straddling a stream() chunk
+            boundary draws two different deltas from the two chunk calls that
+            observe it -- a small, bounded discontinuity in that one cycle per
+            boundary; pinned by a test rather than hidden, see
+            tests/test_signal_impairments.py.
     """
 
     kind: str = "sine"
@@ -99,6 +120,10 @@ class SignalSpec:
         0.1,
         0.05,
     )  # "multitone": relative amplitudes of the 2nd, 3rd, ... harmonic; non-empty by default so SignalSpec(kind="multitone") is not a bit-identical duplicate of "sine"
+    # Appended after harmonics -- the last of the kind-specific fields -- for the
+    # same don't-reorder-positional-construction reason as every field above it,
+    # NOT next to the other impairments where it reads better.
+    jitter_rms: float = 0.0  # seconds of period-to-period timing jitter (0 = off); PERIODIC_KINDS only -- see the docstring above for the model and the sqrt(2) calibration
 
 
 # How close to a whole cycle a sample may sit and still count as landing exactly
@@ -372,6 +397,8 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"ringing_frequency must be non-negative: {spec.ringing_frequency}")
     if spec.ringing_damping < 0:
         raise exceptions.InvalidParameterError(f"ringing_damping must be non-negative: {spec.ringing_damping}")
+    if not np.isfinite(spec.jitter_rms) or spec.jitter_rms < 0:
+        raise exceptions.InvalidParameterError(f"jitter_rms must be a non-negative, finite number: {spec.jitter_rms}")
 
 
 def _impairment_rng(seed: Optional[int], stream_index: int) -> np.random.Generator:
@@ -384,6 +411,68 @@ def _impairment_rng(seed: Optional[int], stream_index: int) -> np.random.Generat
     if seed is None:
         return np.random.default_rng()
     return np.random.default_rng([seed, stream_index])
+
+
+def _jitter_cycle_rng(seed: Optional[int], cycle_index: int) -> np.random.Generator:
+    """An independent, seed-reproducible generator per jittered cycle.
+
+    Keyed by CYCLE INDEX rather than by _impairment_rng's stream position: a
+    given cycle's time-shift must come out identically no matter which buffer
+    observes it -- in particular, ringing's extended lookback window (t_ext,
+    which starts decay_len samples before t0) must see the SAME delta for a
+    cycle that the plain (non-extended) buffer would have drawn for it, or the
+    two would disagree about where that cycle's edge sits. "2" is a fixed
+    namespace tag distinguishing this from the module's other seeded streams
+    (the bare `rng` in synthesize() is seeded directly off spec.seed;
+    _impairment_rng's glitch stream uses index 1), so a jitter draw can never
+    collide with another impairment's draw under the same seed.
+    """
+    if seed is None:
+        return np.random.default_rng()
+    # cycle_index can be negative: ringing's extended lookback window renders
+    # samples before t0, and t0 itself can be negative (a free-running mock's
+    # trigger-relative time base). SeedSequence entries must be non-negative,
+    # so reinterpret the signed 64-bit cycle index as its unsigned bit pattern
+    # -- a bijection, so distinct cycles (negative or not) still get distinct,
+    # deterministic seeds.
+    cycle_component = int(np.uint64(np.int64(cycle_index)))
+    return np.random.default_rng([seed, 2, cycle_component])
+
+
+def _apply_jitter(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
+    """Warp a time array so each cycle's samples land where a jittered edge
+    would actually fall.
+
+    Model: cycle n gets its own Gaussian time-shift delta[n] ~ N(0, sigma),
+    and EVERY sample in that cycle (not just its edge) is shifted by it --
+    t_effective = t - delta[cycle_index(t)], cycle_index(t) = floor(frequency
+    * t + phase / 2pi), the same cycle-counting math _cycle_fraction uses.
+
+    Calibration: a cycle's observed edge lands at n*T + delta[n], so
+    period[n] = T + delta[n+1] - delta[n]; delta[n] and delta[n+1] are
+    independent, so std(period) = sigma * sqrt(2). Using
+    sigma = jitter_rms / sqrt(2) here is what makes `jitter_rms` equal the
+    value a caller measures back out (see SignalSpec.jitter_rms and
+    docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md).
+
+    A no-op (returns `t` unchanged, same object) when jitter_rms is 0 or the
+    kind has no stable period -- PERIODIC_KINDS excludes "dc", "noise" (no
+    cycle structure) and "chirp" (frequency sweeps, so "cycle index" is
+    undefined). That fast path is also what keeps a disabled jitter_rms
+    byte-identical to this feature never having existed: the generator sees
+    the exact same time array it always did.
+    """
+    if spec.jitter_rms <= 0 or spec.kind not in PERIODIC_KINDS:
+        return t
+    cycle_index = np.floor(spec.frequency * t + spec.phase / (2.0 * np.pi)).astype(np.int64)
+    sigma = spec.jitter_rms / np.sqrt(2.0)
+    # One generator per UNIQUE cycle index present in this buffer, not one per
+    # sample: this buffer's ringing extended-window call included, a typical
+    # buffer spans hundreds to low thousands of cycles, not samples, and this
+    # keeps every sample within a cycle reading the identical delta.
+    unique_cycles, inverse = np.unique(cycle_index, return_inverse=True)
+    deltas = np.array([_jitter_cycle_rng(spec.seed, cycle).normal(0.0, sigma) for cycle in unique_cycles])
+    return t - deltas[inverse]
 
 
 def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:
@@ -400,6 +489,12 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     """
     _validate(spec, sample_rate, n_points)
     rng = np.random.default_rng(spec.seed)
+    # `t` stays the NOMINAL time array all the way through this function --
+    # drift below is deliberately a function of absolute time, unwarped. Jitter
+    # (_apply_jitter) is applied only at the two _GENERATORS[...] call sites
+    # below (the plain one and, inside the ringing branch, the extended-window
+    # one), so ringing's own edge detection sees the jittered edge position,
+    # not the nominal one.
     t = t0 + np.arange(n_points) / sample_rate
     if spec.ringing_frequency > 0:
         # A damped sinusoid triggered at each edge. Real probe/scope front-ends
@@ -433,7 +528,7 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
         # (verified: this happened at every chunk boundary in the drift-style
         # continuity test below until reordered this way).
         t_ext = t0 + (np.arange(n_points + decay_len) - decay_len) / sample_rate
-        samples_ext = _GENERATORS[spec.kind](spec, t_ext, rng) + spec.offset
+        samples_ext = _GENERATORS[spec.kind](spec, _apply_jitter(spec, t_ext), rng) + spec.offset
         # ANY nonzero sample-to-sample change is an edge here, not just a
         # discontinuity: on a continuous kind every sample qualifies, so this
         # becomes a derivative-weighted filter rather than a no-op. That is
@@ -464,7 +559,7 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
         else:
             samples = samples_ext[decay_len:]
     else:
-        samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
+        samples = _GENERATORS[spec.kind](spec, _apply_jitter(spec, t), rng) + spec.offset
     if spec.drift_amplitude > 0:
         # Time-based, NOT a random walk: stream() re-seeds per chunk, so a walk
         # would reset at every chunk boundary and a live view would show sawtooth

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -69,23 +69,49 @@ class SignalSpec:
             off). PERIODIC_KINDS only (sine, square, triangle, ramp,
             multitone, exponential, pulse): "dc"/"noise" have no cycle
             structure and "chirp" has no stable period, so on those three
-            kinds this field is a no-op rather than an error. Each cycle gets
-            its own independent Gaussian time-shift and the WHOLE cycle --
-            not just its edge -- moves by it, so an enabled `ringing_frequency`
-            keys on the actual jittered edge, not the nominal one, with no
-            special-casing needed. Calibrated so `jitter_rms` IS the value a
-            caller gets back from measuring the output: the internal per-cycle
-            draw uses sigma = jitter_rms / sqrt(2), because a measured period
-            is the difference of two independent per-cycle deltas
-            (period[n] = T + delta[n+1] - delta[n]), so
-            std(period) = sigma * sqrt(2). See
+            kinds this field is a no-op rather than an error. Each cycle
+            BOUNDARY gets its own independent Gaussian time-shift, and every
+            sample's shift is the LINEAR INTERPOLATION between the two
+            boundaries straddling it -- a continuous warp, not a per-cycle
+            hard step -- so an enabled `ringing_frequency` keys on the actual
+            jittered edge, not the nominal one, with no special-casing needed.
+
+            What you actually measure back depends on WHERE your kind's
+            measurable edge sits within its cycle, because the interpolation
+            blends less of the "wrong" neighbor the closer the edge sits to a
+            boundary. Let f be that edge's fractional position in [0, 1)
+            (f=0 is the cycle boundary itself; _cycle_fraction computes the
+            same fraction for the underlying generator):
+              - An edge AT the cycle boundary (f=0 -- the ascending v50
+                crossing of "sine", "square", "multitone", and "pulse" (whose
+                edge sits within edge_time/2 of the boundary) at their default
+                phase=0.0) gets the full, unblended shift from the boundary on
+                each side, so period[n] = T + delta[n+1] - delta[n] exactly as
+                a per-cycle-constant model would give: measures `jitter_rms`
+                almost exactly (verified empirically: ratio 0.94-1.08 across
+                trials at 1-5% of the period).
+              - An edge at some other in-cycle fraction f gets a BLENDED shift
+                and measures LESS. Two verified examples: "triangle"'s
+                ascending crossing sits at f=0.25 (ratio measured ~0.66-0.68,
+                close to the 0.6614 the formula below predicts); "ramp"'s
+                zero crossing -- despite the ramp's own discontinuity sitting
+                at the boundary -- is itself a continuous ramp, so its v50
+                crossing actually sits at f=0.5, cycle CENTER, the point of
+                MAXIMUM attenuation (ratio measured ~0.50-0.52, matching the
+                formula's minimum of 0.5 almost exactly).
+              Both are consistent with
+              Var(period)/jitter_rms**2 = 0.5*[(1-2f)**2 + f**2 + (1-f)**2],
+              which is 1.0 at f=0 and a minimum of 0.25 (ratio 0.5) at f=0.5.
+            The internal per-boundary draw uses sigma = jitter_rms / sqrt(2),
+            which is what keeps the common f=0 case exactly calibrated. See
             docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md
             for the full derivation. KNOWN LIMITATION: stream() bumps
             spec.seed per chunk, so a cycle straddling a stream() chunk
             boundary draws two different deltas from the two chunk calls that
-            observe it -- a small, bounded discontinuity in that one cycle per
-            boundary; pinned by a test rather than hidden, see
-            tests/test_signal_impairments.py.
+            observe it -- a discontinuity in that one cycle's warp per
+            boundary, spread across the samples between the two control
+            points rather than landing as a single jump; pinned by a test
+            rather than hidden, see tests/test_signal_impairments.py.
     """
 
     kind: str = "sine"
@@ -413,47 +439,81 @@ def _impairment_rng(seed: Optional[int], stream_index: int) -> np.random.Generat
     return np.random.default_rng([seed, stream_index])
 
 
-def _jitter_cycle_rng(seed: Optional[int], cycle_index: int) -> np.random.Generator:
-    """An independent, seed-reproducible generator per jittered cycle.
+def _jitter_cycle_rng(seed: Optional[int], boundary_index: int) -> np.random.Generator:
+    """An independent, seed-reproducible generator per jittered cycle-BOUNDARY.
 
-    Keyed by CYCLE INDEX rather than by _impairment_rng's stream position: a
-    given cycle's time-shift must come out identically no matter which buffer
-    observes it -- in particular, ringing's extended lookback window (t_ext,
-    which starts decay_len samples before t0) must see the SAME delta for a
-    cycle that the plain (non-extended) buffer would have drawn for it, or the
-    two would disagree about where that cycle's edge sits. "2" is a fixed
-    namespace tag distinguishing this from the module's other seeded streams
-    (the bare `rng` in synthesize() is seeded directly off spec.seed;
-    _impairment_rng's glitch stream uses index 1), so a jitter draw can never
-    collide with another impairment's draw under the same seed.
+    Keyed by BOUNDARY INDEX rather than by _impairment_rng's stream position: a
+    given boundary's time-shift must come out identically no matter which
+    buffer observes it -- in particular, ringing's extended lookback window
+    (t_ext, which starts decay_len samples before t0) must see the SAME delta
+    for a boundary that the plain (non-extended) buffer would have drawn for
+    it, or the two would disagree about where an edge near that boundary sits.
+    "2" is a fixed namespace tag distinguishing this from the module's other
+    seeded streams (the bare `rng` in synthesize() is seeded directly off
+    spec.seed; _impairment_rng's glitch stream uses index 1), so a jitter draw
+    can never collide with another impairment's draw under the same seed.
+
+    Named "_cycle_rng" (not "_boundary_rng") for continuity with existing
+    callers/tests: a boundary index IS a cycle index -- boundary n is simply
+    the point in time cycle n begins -- this function's contract (one
+    reproducible draw per integer index) hasn't changed, only how
+    _apply_jitter combines two adjacent draws.
     """
     if seed is None:
         return np.random.default_rng()
-    # cycle_index can be negative: ringing's extended lookback window renders
-    # samples before t0, and t0 itself can be negative (a free-running mock's
-    # trigger-relative time base). SeedSequence entries must be non-negative,
-    # so reinterpret the signed 64-bit cycle index as its unsigned bit pattern
-    # -- a bijection, so distinct cycles (negative or not) still get distinct,
-    # deterministic seeds.
-    cycle_component = int(np.uint64(np.int64(cycle_index)))
-    return np.random.default_rng([seed, 2, cycle_component])
+    # boundary_index can be negative: ringing's extended lookback window
+    # renders samples before t0, and t0 itself can be negative (a free-running
+    # mock's trigger-relative time base). SeedSequence entries must be
+    # non-negative, so reinterpret the signed 64-bit index as its unsigned bit
+    # pattern -- a bijection, so distinct boundaries (negative or not) still
+    # get distinct, deterministic seeds.
+    boundary_component = int(np.uint64(np.int64(boundary_index)))
+    return np.random.default_rng([seed, 2, boundary_component])
 
 
 def _apply_jitter(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
-    """Warp a time array so each cycle's samples land where a jittered edge
-    would actually fall.
+    """Warp a time array by linearly interpolating a jittered delta between
+    cycle-BOUNDARY control points, so every sample's shift varies continuously
+    (no hard steps) instead of jumping once per cycle.
 
-    Model: cycle n gets its own Gaussian time-shift delta[n] ~ N(0, sigma),
-    and EVERY sample in that cycle (not just its edge) is shifted by it --
-    t_effective = t - delta[cycle_index(t)], cycle_index(t) = floor(frequency
-    * t + phase / 2pi), the same cycle-counting math _cycle_fraction uses.
+    Model: boundary n (the instant cycle n begins) gets its own Gaussian
+    time-shift d[n] ~ N(0, sigma). For a sample at continuous cycle position
+    `pos = frequency*t + phase/2pi`, let n = floor(pos) and frac = pos - n in
+    [0, 1). The sample's delta is the linear blend of the two boundaries that
+    straddle it: delta(t) = d[n]*(1-frac) + d[n+1]*frac, and
+    t_effective = t - delta(t).
 
-    Calibration: a cycle's observed edge lands at n*T + delta[n], so
-    period[n] = T + delta[n+1] - delta[n]; delta[n] and delta[n+1] are
-    independent, so std(period) = sigma * sqrt(2). Using
-    sigma = jitter_rms / sqrt(2) here is what makes `jitter_rms` equal the
-    value a caller measures back out (see SignalSpec.jitter_rms and
-    docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md).
+    This replaces an earlier hard-step model (delta = d[cycle_index(t)], a
+    per-cycle constant) that was found to make t_effective NON-MONOTONIC --
+    going backward in time -- whenever |d[n+1]-d[n]| exceeded one sample
+    interval dt, which happens at ordinary jitter values and corrupted edge
+    detection (spurious double-edges, 10-30x measurement inflation) on 5 of
+    7 PERIODIC_KINDS. The interpolated model is C0-continuous everywhere, so
+    t_effective stays monotonic as long as |d[n+1]-d[n]| < T (one period) --
+    verified empirically to hold at the jitter magnitudes this feature
+    targets, a vastly higher bar than the old model's < dt.
+
+    Calibration is now EDGE-POSITION DEPENDENT, not a single constant. An
+    edge sitting exactly at a cycle boundary (frac=0, e.g. sine/square/
+    multitone/pulse's ascending v50 crossing at the default phase=0.0) gets
+    the full, unblended d[n] shift on one side and d[n+1] on the other, so
+    period[n] = T + d[n+1] - d[n] exactly as under the old model:
+    std(period) = sigma*sqrt(2) = jitter_rms, unchanged (verified empirically:
+    ratio 0.94-1.08 at 1-5% of the period). An edge at some other in-cycle
+    fraction f gets a BLENDED shift and consecutive such edges are no longer
+    independent; verified empirically at two more points --
+    Var(period)/jitter_rms**2 = 0.5*[(1-2f)**2 + f**2 + (1-f)**2] -- "triangle"
+    (f=0.25, measured ratio ~0.66-0.68 vs. the formula's 0.6614) and "ramp"
+    (whose v50 crossing, despite the RAMP's own hard discontinuity sitting at
+    the boundary, is itself continuous and actually sits at f=0.5, cycle
+    center: measured ratio ~0.50-0.52 vs. the formula's minimum of 0.5).
+    Using sigma = jitter_rms / sqrt(2) here keeps the frac=0 case exactly
+    calibrated, which is the common case (every PERIODIC_KINDS default phase
+    puts its edge at or within edge_time/2 of a boundary, except "triangle"
+    at f=0.25 and "ramp" at f=0.5). See SignalSpec.jitter_rms for the
+    caller-facing summary and
+    docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md for the
+    full derivation.
 
     A no-op (returns `t` unchanged, same object) when jitter_rms is 0 or the
     kind has no stable period -- PERIODIC_KINDS excludes "dc", "noise" (no
@@ -464,15 +524,21 @@ def _apply_jitter(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
     """
     if spec.jitter_rms <= 0 or spec.kind not in PERIODIC_KINDS:
         return t
-    cycle_index = np.floor(spec.frequency * t + spec.phase / (2.0 * np.pi)).astype(np.int64)
+    pos = spec.frequency * t + spec.phase / (2.0 * np.pi)
+    n = np.floor(pos).astype(np.int64)
+    frac = pos - n
     sigma = spec.jitter_rms / np.sqrt(2.0)
-    # One generator per UNIQUE cycle index present in this buffer, not one per
-    # sample: this buffer's ringing extended-window call included, a typical
-    # buffer spans hundreds to low thousands of cycles, not samples, and this
-    # keeps every sample within a cycle reading the identical delta.
-    unique_cycles, inverse = np.unique(cycle_index, return_inverse=True)
-    deltas = np.array([_jitter_cycle_rng(spec.seed, cycle).normal(0.0, sigma) for cycle in unique_cycles])
-    return t - deltas[inverse]
+    # One generator per UNIQUE boundary index needed by this buffer -- the
+    # boundary before (n) and after (n + 1) each sample -- not one per sample:
+    # this buffer's ringing extended-window call included, a typical buffer
+    # spans hundreds to low thousands of cycles, not samples.
+    boundary_indices, inverse = np.unique(np.concatenate([n, n + 1]), return_inverse=True)
+    boundary_deltas = np.array([_jitter_cycle_rng(spec.seed, idx).normal(0.0, sigma) for idx in boundary_indices])
+    half = n.size
+    d_before = boundary_deltas[inverse[:half]]
+    d_after = boundary_deltas[inverse[half:]]
+    delta = d_before * (1.0 - frac) + d_after * frac
+    return t - delta
 
 
 def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -357,7 +357,16 @@ def test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolera
     assert measured == pytest.approx(jitter_rms, rel=0.25)
 
 
-@pytest.mark.parametrize("kind", ["sine", "square", "ramp", "multitone"])
+# "pulse"'s rising v50 crossing sits at edge_time/2 into the cycle (see
+# _pulse), not exactly at the boundary like "square"'s -- but at the default
+# 10 us edge_time and a 100 us period (frequency=10 kHz below) that is
+# f=edge_time/(2*period)=0.005, close enough to f=0 to belong in this group.
+# pulse_width/edge_time are scaled down (same 20%/1% duty ratio as the
+# dataclass defaults) so the trapezoid still fits inside that 100 us period.
+_PULSE_KWARGS = {"pulse_width": 2e-5, "edge_time": 1e-6}
+
+
+@pytest.mark.parametrize("kind", ["sine", "square", "ramp", "multitone", "pulse"])
 def test_jitter_produces_no_spurious_edges_on_previously_broken_kinds(kind):
     """The direct proof the fix closes the gap the prior review found: under
     the old hard-step-per-cycle model, sine/square/ramp/multitone/pulse (5 of
@@ -378,10 +387,11 @@ def test_jitter_produces_no_spurious_edges_on_previously_broken_kinds(kind):
     frequency = 10_000.0
     period = 1.0 / frequency
     n = 50_000
+    extra_kwargs = _PULSE_KWARGS if kind == "pulse" else {}
     for pct in (0.01, 0.03, 0.05):
         jitter_rms = pct * period
         for seed in (1, 2, 3):
-            spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=seed)
+            spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=seed, **extra_kwargs)
             v = synthesize(spec, rate, n)
             v50 = (float(np.max(v)) + float(np.min(v))) / 2.0
             rising = np.flatnonzero((v[:-1] < v50) & (v[1:] >= v50))
@@ -398,6 +408,7 @@ def test_jitter_produces_no_spurious_edges_on_previously_broken_kinds(kind):
         ("sine", 0.0, 1.0),
         ("triangle", 0.25, 0.6614),
         ("ramp", 0.5, 0.5),
+        ("pulse", 0.005, 1.0),
     ],
 )
 def test_jitter_measured_ratio_depends_on_edge_fraction_within_the_cycle(kind, edge_fraction, expected_ratio):
@@ -412,20 +423,32 @@ def test_jitter_measured_ratio_depends_on_edge_fraction_within_the_cycle(kind, e
     that is a FALLING transition -- the analyzer's RISING v50 crossing is the
     ramp's own continuous rise from -amplitude to +amplitude, which crosses
     zero at f=0.5, cycle CENTER, the formula's minimum (predicted ratio 0.5).
+    "pulse"'s rising v50 crossing sits at edge_time/2 into the cycle (see
+    _pulse's docstring), not exactly at the boundary -- with the scaled-down
+    `_PULSE_KWARGS` (pulse_width=2e-5 s, edge_time=1e-6 s) at this test's 100
+    us period that is f=1e-6/(2e-4)=0.005, close enough to f=0 that the
+    formula predicts ratio sqrt(0.5*(0.99**2+0.005**2+0.995**2))~=0.9925 --
+    indistinguishable from sine's f=0 at this test's tolerance, which is
+    exactly the point: this is the "verified" half of the CHANGELOG's ~1.0
+    claim for "pulse" that was previously untested (measured 0.95-1.03 across
+    a 6-seed sample taken during verification, comfortably inside the
+    documented 0.94-1.08 band).
 
     RATE=1 MHz, frequency=10 kHz, N=50_000 (~500 cycles), jitter_rms = 3% of
     the period, seed=0 -- chosen because it lands close to each kind's
     respective mean across a 5-seed sample taken during verification (sine
-    0.96, triangle 0.688, ramp 0.537, vs. predicted 1.0/0.6614/0.5). A +/-20%
-    relative tolerance comfortably covers single-seed sampling variation at
-    ~500 cycles while still distinguishing the three fractions from each
-    other and from a same-for-every-kind (unfixed) model.
+    0.96, triangle 0.688, ramp 0.537, pulse 0.968, vs. predicted
+    1.0/0.6614/0.5/0.9925). A +/-20% relative tolerance comfortably covers
+    single-seed sampling variation at ~500 cycles while still distinguishing
+    the fractions from each other and from a same-for-every-kind (unfixed)
+    model.
     """
     rate = 1_000_000.0
     frequency = 10_000.0
     n = 50_000
     jitter_rms = 0.03 / frequency
-    spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=0)
+    extra_kwargs = _PULSE_KWARGS if kind == "pulse" else {}
+    spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=0, **extra_kwargs)
     waveform = make_waveform(spec, rate, n)
     measured = WaveformAnalyzer.calculate_quality_stats(waveform)["jitter"]
     assert measured is not None

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -243,10 +243,18 @@ def test_ringing_is_continuous_across_stream_chunks():
 
 # --- jitter_rms -------------------------------------------------------------
 #
-# Each cycle gets an independent Gaussian time-shift and the whole cycle moves
-# by it (see SignalSpec.jitter_rms and the design doc). Calibrated so
-# jitter_rms IS the value WaveformAnalyzer's own period-jitter measurement
-# reports back (sigma = jitter_rms / sqrt(2) internally).
+# Each cycle BOUNDARY gets an independent Gaussian time-shift, and every
+# sample's shift is the linear interpolation between the two boundaries that
+# straddle it (see SignalSpec.jitter_rms and the design doc). This replaced an
+# earlier hard-step-per-cycle model that made the warped time axis
+# non-monotonic at ordinary jitter values, corrupting edge detection (spurious
+# double-edges, 10-30x measurement inflation) on 5 of 7 PERIODIC_KINDS --
+# fixed by this file's tests below. Calibration is now EDGE-POSITION
+# DEPENDENT: an edge sitting exactly at a cycle boundary (fraction 0) measures
+# jitter_rms almost exactly (sigma = jitter_rms / sqrt(2) internally is tuned
+# for this case); an edge elsewhere in the cycle measures less, following
+# Var(period)/jitter_rms**2 = 0.5*[(1-2f)**2 + f**2 + (1-f)**2] -- verified
+# empirically below for f=0 (sine), f=0.25 (triangle), and f=0.5 (ramp).
 
 
 def test_jitter_rms_defaults_to_off():
@@ -284,13 +292,15 @@ def test_jitter_moves_the_measured_period_jitter_off_zero():
     merely "near" zero) -- proving the control is actually clean -- and
     enabling jitter_rms must move it well off that floor.
 
-    "triangle", not "sine": see
-    test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolerance
-    for why sine's rising zero-crossing is the wrong kind to measure jitter on
-    with this analyzer. At RATE=100_000/frequency=1_000 (an exact 100
-    samples/cycle), the clean triangle's ascending v50 crossing lands on the
-    identical sample index every cycle -- period is a constant integer, so
-    std(periods) is exactly 0.0, not just small.
+    "triangle": at RATE=100_000/frequency=1_000 (an exact 100 samples/cycle),
+    the clean signal's rising v50 crossing lands on the identical sample index
+    every cycle regardless of kind -- period is a constant integer, so
+    std(periods) is exactly 0.0, not just small. Triangle is used here (rather
+    than the default "sine") only because it is also the kind exercised by the
+    fraction-dependent-attenuation tests below; either kind demonstrates the
+    same off-zero behaviour equally well now that the interpolated model (see
+    the section comment above) makes every PERIODIC_KINDS measurement
+    reliable, not just this one.
     """
     spec_clean = SignalSpec(kind="triangle", frequency=1_000.0, amplitude=1.0, seed=4)
     spec_jittered = SignalSpec(kind="triangle", frequency=1_000.0, amplitude=1.0, jitter_rms=5e-6, seed=4)
@@ -307,22 +317,22 @@ def test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolera
     jittered signal must come back close to the INJECTED jitter_rms, not
     merely internally self-consistent with this module's own math.
 
-    Deliberately "triangle", not "sine" -- verified empirically, not assumed:
-    a sine's rising zero-crossing sits EXACTLY at fraction 0, the cycle wrap
-    where this feature's own per-cycle delta discontinuity lands (delta[n] is
-    used for every sample up to the wrap, delta[n+1] immediately after it).
-    Right at that steepest-slope point, a jump of |delta[n+1]-delta[n]|
-    comparable to one sample period can make the discretized sine
-    non-monotonic through the v50 threshold, producing a SPURIOUS extra
-    "rising edge" a couple of samples after the real one (reproduced: at
-    jitter_rms=1e-6 s here, sine gave 22/522 anomalous 2-6-sample "periods",
-    inflating measured jitter to ~20x the injected value). "triangle"'s
-    ascending v50 crossing sits at fraction 0.25 -- entirely inside one cycle,
-    using that cycle's single delta uniformly, nowhere near the fraction-0
-    wrap -- so the same delta discontinuity never lands anywhere close to the
-    measurement point (reproduced clean: 0 anomalous periods up to
-    jitter_rms=1e-5 s at this rate; the same 1e-6 s case that broke sine
-    measured ratio 1.08).
+    "sine" -- the DEFAULT kind -- is exactly the validation path the original
+    design doc's Testing section intended and the hard-step model's bug
+    blocked: a sine's rising zero-crossing sits EXACTLY at fraction 0, the
+    cycle boundary, where the OLD per-cycle-constant model's discontinuity
+    landed (a jump of |delta[n+1]-delta[n]| right at the steepest-slope point
+    made the discretized sine non-monotonic through the v50 threshold,
+    producing spurious extra "rising edges" -- reproduced pre-fix: 22/522
+    anomalous 2-6-sample "periods" at jitter_rms=1e-6 s, inflating measured
+    jitter to ~20x injected). The interpolated model (see this file's jitter
+    section comment) is continuous everywhere, so that failure mode is gone;
+    see test_jitter_produces_no_spurious_edges_on_previously_broken_kinds
+    below for the direct proof. Because a fraction-0 edge is also the
+    UNBLENDED case (SignalSpec.jitter_rms), sine is additionally the kind
+    where measured jitter should track injected jitter_rms most closely -- see
+    test_jitter_measured_ratio_depends_on_edge_fraction_within_the_cycle for
+    kinds whose edge sits elsewhere in the cycle.
 
     RATE=1 MHz, frequency=10 kHz -> 100 samples/cycle; N=50_000 -> 500 cycles,
     so calculate_quality_stats sees ~499 measured periods. Treating those as
@@ -335,16 +345,91 @@ def test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolera
     relative tolerance is >7 standard errors, comfortably ruling out random
     flakiness while still catching a wrong calibration constant -- a missing
     sqrt(2) would read ~41% high or ~29% low, both well outside this band.
-    Measured 1.0024x the injected value with these exact parameters.
+    Measured 0.9699x the injected value with these exact parameters (seed=21).
     """
     rate = 1_000_000.0
     n = 50_000
     jitter_rms = 3e-6
-    spec = SignalSpec(kind="triangle", frequency=10_000.0, amplitude=1.0, jitter_rms=jitter_rms, seed=21)
+    spec = SignalSpec(kind="sine", frequency=10_000.0, amplitude=1.0, jitter_rms=jitter_rms, seed=21)
     waveform = make_waveform(spec, rate, n)
     measured = WaveformAnalyzer.calculate_quality_stats(waveform)["jitter"]
     assert measured is not None
     assert measured == pytest.approx(jitter_rms, rel=0.25)
+
+
+@pytest.mark.parametrize("kind", ["sine", "square", "ramp", "multitone"])
+def test_jitter_produces_no_spurious_edges_on_previously_broken_kinds(kind):
+    """The direct proof the fix closes the gap the prior review found: under
+    the old hard-step-per-cycle model, sine/square/ramp/multitone/pulse (5 of
+    7 PERIODIC_KINDS) all produced spurious double-edges at ordinary jitter
+    values (reproduced pre-fix, e.g. sine: 22/522 anomalous periods at
+    jitter_rms = 1% of the period). An "anomalous" period here is one under
+    half the median -- a real, isolated Gaussian jitter draw essentially never
+    produces one (periods cluster tightly around T with std << T/2 at these
+    magnitudes), so any anomaly at all is symptomatic of the old bug, not
+    statistical noise.
+
+    RATE=1 MHz, frequency=10 kHz -> 100 samples/cycle, N=50_000 -> ~500 edges
+    per trial. Three seeds x three jitter levels (1%, 3%, 5% of the period --
+    covering and exceeding the levels that broke the old model) gives 9 trials
+    per kind, ~4500 edges total, with zero anomalies tolerated.
+    """
+    rate = 1_000_000.0
+    frequency = 10_000.0
+    period = 1.0 / frequency
+    n = 50_000
+    for pct in (0.01, 0.03, 0.05):
+        jitter_rms = pct * period
+        for seed in (1, 2, 3):
+            spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=seed)
+            v = synthesize(spec, rate, n)
+            v50 = (float(np.max(v)) + float(np.min(v))) / 2.0
+            rising = np.flatnonzero((v[:-1] < v50) & (v[1:] >= v50))
+            assert rising.size > 400, f"{kind} pct={pct} seed={seed}: too few edges detected to judge -- test setup problem"
+            periods = np.diff(rising)
+            median = np.median(periods)
+            anomalies = np.sum(periods < median * 0.5)
+            assert anomalies == 0, f"{kind} pct={pct} seed={seed}: {anomalies} spurious short period(s) out of {periods.size} -- the old hard-step bug would reproduce here"
+
+
+@pytest.mark.parametrize(
+    "kind, edge_fraction, expected_ratio",
+    [
+        ("sine", 0.0, 1.0),
+        ("triangle", 0.25, 0.6614),
+        ("ramp", 0.5, 0.5),
+    ],
+)
+def test_jitter_measured_ratio_depends_on_edge_fraction_within_the_cycle(kind, edge_fraction, expected_ratio):
+    """Characterizes the real side effect of whole-cycle linear interpolation:
+    an edge's measured jitter depends on WHERE in the cycle it sits, per
+    Var(period)/jitter_rms**2 = 0.5*[(1-2f)**2 + f**2 + (1-f)**2] (see
+    SignalSpec.jitter_rms and _apply_jitter). f=0 (the cycle boundary --
+    "sine"'s ascending v50 crossing at the default phase=0.0) is the
+    UNBLENDED case, predicted ratio 1.0. "triangle"'s ascending crossing sits
+    at f=0.25 (predicted ratio sqrt(0.4375) ~= 0.6614). "ramp" is the
+    surprising one: its own hard discontinuity sits at the cycle boundary, but
+    that is a FALLING transition -- the analyzer's RISING v50 crossing is the
+    ramp's own continuous rise from -amplitude to +amplitude, which crosses
+    zero at f=0.5, cycle CENTER, the formula's minimum (predicted ratio 0.5).
+
+    RATE=1 MHz, frequency=10 kHz, N=50_000 (~500 cycles), jitter_rms = 3% of
+    the period, seed=0 -- chosen because it lands close to each kind's
+    respective mean across a 5-seed sample taken during verification (sine
+    0.96, triangle 0.688, ramp 0.537, vs. predicted 1.0/0.6614/0.5). A +/-20%
+    relative tolerance comfortably covers single-seed sampling variation at
+    ~500 cycles while still distinguishing the three fractions from each
+    other and from a same-for-every-kind (unfixed) model.
+    """
+    rate = 1_000_000.0
+    frequency = 10_000.0
+    n = 50_000
+    jitter_rms = 0.03 / frequency
+    spec = SignalSpec(kind=kind, frequency=frequency, amplitude=1.0, jitter_rms=jitter_rms, seed=0)
+    waveform = make_waveform(spec, rate, n)
+    measured = WaveformAnalyzer.calculate_quality_stats(waveform)["jitter"]
+    assert measured is not None
+    assert measured == pytest.approx(expected_ratio * jitter_rms, rel=0.20)
 
 
 def test_jitter_is_reproducible_under_a_seed():
@@ -379,13 +464,25 @@ def test_jitter_shifts_where_ringing_anchors():
     the physically-correct behaviour the design doc calls out as needing no
     special-casing in the ringing code path itself.
 
-    signal_synth._jitter_cycle_rng(seed, 0) is called directly to obtain
-    cycle 0's delta -- this is ground truth precisely because it is the same
-    seeded-generator call synthesize() itself makes internally for that cycle,
-    not an independent re-derivation of the math. ringing_damping=200_000 (vs.
-    the module's usual 5_000) is deliberate: it shrinks the decay kernel to
-    ~25 samples so the ring stays local to its own edge and cannot spill into
-    -- or be confused with -- ringing from a neighbouring cycle's edge.
+    Targets the RISING edge at the cycle-1 BOUNDARY (nominal sample 1000, not
+    cycle 0's falling duty-threshold edge at sample 500 used before this fix):
+    under the old per-cycle-constant model, EVERY sample in a cycle shifted by
+    that cycle's single delta, so predicting any edge from one delta value was
+    exact. Under the new interpolated model that is only true again AT a
+    boundary sample (frac=0 by construction: delta = d[n]*(1-0) + d[n+1]*0 =
+    d[n] exactly), which is why this test now targets a boundary-fraction edge
+    specifically -- see
+    test_jitter_measured_ratio_depends_on_edge_fraction_within_the_cycle for
+    why an interior-fraction edge (e.g. the OLD test's duty=0.5 target) would
+    no longer be a simple single-delta prediction.
+
+    signal_synth._jitter_cycle_rng(seed, 1) is called directly to obtain
+    boundary 1's delta -- this is ground truth precisely because it is the
+    same seeded-generator call synthesize() itself makes internally for that
+    boundary, not an independent re-derivation of the math. ringing_damping=
+    200_000 (vs. the module's usual 5_000) is deliberate: it shrinks the decay
+    kernel to ~25 samples so the ring stays local to its own edge and cannot
+    spill into -- or be confused with -- ringing from a neighbouring edge.
     """
     rate = 1_000_000.0
     n = 4_000
@@ -398,35 +495,35 @@ def test_jitter_shifts_where_ringing_anchors():
     rung_jittered = synthesize(SignalSpec(jitter_rms=jitter_rms, ringing_frequency=50_000.0, ringing_damping=200_000.0, **base), rate, n)
 
     sigma = jitter_rms / np.sqrt(2.0)
-    delta0 = signal_synth._jitter_cycle_rng(seed, 0).normal(0.0, sigma)
-    # Cycle 0's own falling (duty-threshold) edge is nominally at sample 500
-    # (duty * samples-per-cycle = 0.5 * 1000) and, being entirely inside
-    # cycle 0, shifts by cycle 0's own delta alone.
-    predicted_edge = 500 + delta0 * rate
+    delta1 = signal_synth._jitter_cycle_rng(seed, 1).normal(0.0, sigma)
+    # Boundary 1 (the rising transition into cycle 1) is nominally at sample
+    # 1000 (1 * samples-per-cycle); a sample exactly at a boundary is the
+    # UNBLENDED case, so it shifts by that boundary's own delta alone.
+    predicted_edge = 1000 + delta1 * rate
 
-    nominal_falling = np.flatnonzero(np.diff(clean) < 0)[0] + 1
-    assert nominal_falling == 500, "sanity check on the nominal edge position"
-    assert abs(predicted_edge - 500) > 30, "test parameters should produce a shift large enough to be unambiguous -- widen jitter_rms if this ever fails"
+    nominal_rising = np.flatnonzero(np.diff(clean) > 0)[0] + 1
+    assert nominal_rising == 1000, "sanity check on the nominal edge position"
+    assert abs(predicted_edge - 1000) > 20, "test parameters should produce a shift large enough to be unambiguous -- widen jitter_rms if this ever fails"
 
     # Search a window centered on the PREDICTED position, not a blind scan of
     # the whole cycle -- ringing's own damped oscillation produces many small
-    # sample-to-sample sign flips as it decays, so "first negative diff
+    # sample-to-sample sign flips as it decays, so "first positive diff
     # anywhere" is not a safe way to find the real transition once ringing is
     # on; anchoring the search to the predicted location is.
     lo = int(predicted_edge) - 30
-    falling_in_window = np.flatnonzero(np.diff(rung_jittered[lo : lo + 60]) < 0)
-    assert falling_in_window.size > 0, "expected a falling edge near the predicted jittered position"
-    actual_edge = lo + falling_in_window[0] + 1
+    rising_in_window = np.flatnonzero(np.diff(rung_jittered[lo : lo + 60]) > 0)
+    assert rising_in_window.size > 0, "expected a rising edge near the predicted jittered position"
+    actual_edge = lo + rising_in_window[0] + 1
 
-    assert actual_edge == pytest.approx(predicted_edge, abs=2.0), "the edge must land at the jittered position, not the nominal grid position 500"
+    assert actual_edge == pytest.approx(predicted_edge, abs=3.0), "the edge must land at the jittered position, not the nominal grid position 1000"
 
     # And the ring itself (an edge impairment) must be anchored at that ACTUAL
     # edge: the samples right after it should show much more oscillation than
-    # the same-width window sitting at the now-wrong nominal position 500,
+    # the same-width window sitting at the now-wrong nominal position 1000,
     # where (with this short a decay kernel) the ring has already fully died
-    # out by the time cycle 0's real transition happens elsewhere.
+    # out by the time cycle 1's real transition happens elsewhere.
     ring_at_actual = rung_jittered[actual_edge : actual_edge + 15]
-    ring_at_nominal = rung_jittered[500:515]
+    ring_at_nominal = rung_jittered[1000:1015]
     assert np.std(ring_at_actual) > 0.1
     assert np.std(ring_at_nominal) == 0.0, "sanity check: this short ringing kernel should have fully settled by the (now-empty) nominal edge position"
 
@@ -436,23 +533,37 @@ def test_jitter_across_a_stream_chunk_boundary_is_a_pinned_known_limitation():
     stream() bumps spec.seed by chunk_index per chunk (existing, deliberate
     behaviour -- see stream()'s own docstring). A cycle that straddles a
     stream() chunk boundary is rendered by TWO different synthesize() calls --
-    one per chunk -- each using a different seed, so
-    _jitter_cycle_rng(seed, cycle) draws a DIFFERENT, uncorrelated delta for
-    the SAME cycle depending on which half of it is being rendered.
+    one per chunk -- each computing this cycle's two boundary deltas
+    (_jitter_cycle_rng(seed, n) and (..., n + 1)) under a DIFFERENT seed, so
+    the SAME nominal cycle gets two different, uncorrelated control-point
+    pairs depending on which half of it is being rendered.
 
     This is NOT merely "the jump at this boundary looks bigger than average":
     a jump between one cycle and the next is EXPECTED and normal everywhere in
     this model (that is what produces jitter's period variation in the first
     place -- see SignalSpec.jitter_rms), so an ordinary between-cycle jump is
     no evidence of anything wrong. The actual defect is narrower: a
-    within-cycle inconsistency where two samples that belong to the SAME
-    nominal cycle (cyc_before == cyc_after below) get shifted by two DIFFERENT
-    deltas, only because stream() happened to cut the buffer there. This test
-    pins that precisely by reproducing, from the seeded generators directly,
-    exactly which two deltas produced the streamed samples on either side of
-    each chunk boundary -- and contrasting that with `contiguous`, where the
-    same cycle uses a SINGLE delta (spec.seed, unbumped) throughout, so it has
-    no such inconsistency.
+    within-cycle inconsistency where two ADJACENT samples that belong to the
+    SAME nominal cycle (n_before == n_after below) get interpolated deltas
+    computed from two DIFFERENT boundary-delta pairs, only because stream()
+    happened to cut the buffer there.
+
+    Under the OLD hard-step model this showed up as a single-sample jump of a
+    constant size (one delta difference). Under the NEW interpolated model the
+    shape changed: the jump size now also depends on WHERE in the cycle the
+    stream boundary happens to fall (the frac-weighted blend of two
+    independent delta differences, not one) -- reproduced below at
+    frequency=997.0/chunk_size=1_000: the streamed reconstruction's delta jump
+    at each of the three probed boundaries is ~1e-5, roughly two orders of
+    magnitude larger than the SAME two adjacent samples' delta difference
+    under one contiguous call (~4e-7, the ordinary sub-sample drift of a
+    smooth interpolation -- not a defect, ~4e-7 s corresponds to well under
+    half a sample at RATE=100_000). This test pins that precisely by
+    reproducing, from the seeded generators directly, exactly which boundary
+    deltas produced the streamed samples on either side of each chunk
+    boundary -- and contrasting that with `contiguous`, where every sample
+    uses boundary deltas from a SINGLE seed throughout, so it has no such
+    inconsistency.
 
     frequency=997.0 and chunk_size=1_000 (as in the ringing continuity test
     above) put a chunk boundary in the middle of most cycles, not on one.
@@ -467,33 +578,60 @@ def test_jitter_across_a_stream_chunk_boundary_is_a_pinned_known_limitation():
     sigma = spec.jitter_rms / np.sqrt(2.0)
     dt = 1.0 / RATE
     chunk_size = 1_000
+
+    def boundary_delta(seed_offset, idx):
+        return signal_synth._jitter_cycle_rng(spec.seed + seed_offset, idx).normal(0.0, sigma)
+
     boundaries_straddling_one_cycle = 0
     for b in (1_000, 2_000, 3_000):
         t_before, t_after = (b - 1) * dt, b * dt
-        cyc_before = int(np.floor(spec.frequency * t_before))
-        cyc_after = int(np.floor(spec.frequency * t_after))
-        if cyc_before != cyc_after:
+        pos_before = spec.frequency * t_before + spec.phase / (2.0 * np.pi)
+        pos_after = spec.frequency * t_after + spec.phase / (2.0 * np.pi)
+        n_before = int(np.floor(pos_before))
+        n_after = int(np.floor(pos_after))
+        if n_before != n_after:
             continue  # this particular boundary happened to land exactly on a cycle wrap -- nothing to pin
         boundaries_straddling_one_cycle += 1
+        frac_before = pos_before - n_before
+        frac_after = pos_after - n_after
 
         chunk_before, chunk_after = (b - 1) // chunk_size, b // chunk_size
-        delta_before = signal_synth._jitter_cycle_rng(spec.seed + chunk_before, cyc_before).normal(0.0, sigma)
-        delta_after = signal_synth._jitter_cycle_rng(spec.seed + chunk_after, cyc_after).normal(0.0, sigma)
-        assert delta_before != delta_after, "the whole point of the limitation: the SAME cycle drew two different deltas"
 
-        # The streamed reconstruction must match the TWO-delta (inconsistent)
+        d_before_n = boundary_delta(chunk_before, n_before)
+        d_before_n1 = boundary_delta(chunk_before, n_before + 1)
+        d_after_n = boundary_delta(chunk_after, n_after)
+        d_after_n1 = boundary_delta(chunk_after, n_after + 1)
+        assert (d_before_n, d_before_n1) != (d_after_n, d_after_n1), "the whole point of the limitation: the SAME cycle's boundary deltas differ depending on which chunk rendered them"
+
+        delta_before = d_before_n * (1.0 - frac_before) + d_before_n1 * frac_before
+        delta_after = d_after_n * (1.0 - frac_after) + d_after_n1 * frac_after
+
+        # The streamed reconstruction must match the TWO-CHUNK (inconsistent)
         # prediction, sample for sample.
         predicted_before = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_before - delta_before) + spec.phase)
         predicted_after = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_after - delta_after) + spec.phase)
         assert streamed[b - 1] == pytest.approx(predicted_before, abs=1e-9)
         assert streamed[b] == pytest.approx(predicted_after, abs=1e-9)
 
-        # Whereas the single contiguous call used ONE delta (unbumped
-        # spec.seed) for this entire cycle -- no within-cycle jump.
-        delta_whole_cycle = signal_synth._jitter_cycle_rng(spec.seed, cyc_before).normal(0.0, sigma)
-        predicted_contiguous_before = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_before - delta_whole_cycle) + spec.phase)
-        predicted_contiguous_after = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_after - delta_whole_cycle) + spec.phase)
-        assert contiguous[b - 1] == pytest.approx(predicted_contiguous_before, abs=1e-9)
-        assert contiguous[b] == pytest.approx(predicted_contiguous_after, abs=1e-9)
+        # Whereas the single contiguous call used boundary deltas from ONE
+        # seed (unbumped spec.seed) throughout -- its own before/after delta
+        # difference is just the ordinary smooth interpolation drift over one
+        # sample, not a chunk-seam artifact.
+        d_contig_n = boundary_delta(0, n_before)
+        d_contig_n1 = boundary_delta(0, n_before + 1)
+        delta_contig_before = d_contig_n * (1.0 - frac_before) + d_contig_n1 * frac_before
+        delta_contig_after = d_contig_n * (1.0 - frac_after) + d_contig_n1 * frac_after
+        predicted_contig_before = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_before - delta_contig_before) + spec.phase)
+        predicted_contig_after = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_after - delta_contig_after) + spec.phase)
+        assert contiguous[b - 1] == pytest.approx(predicted_contig_before, abs=1e-9)
+        assert contiguous[b] == pytest.approx(predicted_contig_after, abs=1e-9)
+
+        # Characterizes the "spread-out ramp, not a hard jump" shape change:
+        # the streamed seam's delta discontinuity is real and an order of
+        # magnitude (or more) larger than the ordinary one-sample drift the
+        # same two samples show under one contiguous, self-consistent call.
+        jump_streamed = abs(delta_after - delta_before)
+        jump_contiguous = abs(delta_contig_after - delta_contig_before)
+        assert jump_streamed > 10 * jump_contiguous, "the chunk-boundary discontinuity should dwarf ordinary within-cycle interpolation drift"
 
     assert boundaries_straddling_one_cycle > 0, "test setup should produce at least one boundary that actually straddles a single cycle"

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -1,4 +1,4 @@
-"""Signal impairments: drift, glitches and edge ringing.
+"""Signal impairments: drift, glitches, edge ringing, and timing jitter.
 
 The mock produced mathematically perfect waveforms, so measurement code had never
 faced an imperfect signal. These impairments are all DEFAULT OFF -- the
@@ -9,8 +9,9 @@ default would silently change what every existing mock-based test measures.
 import numpy as np
 import pytest
 
-from scpi_control import exceptions
-from scpi_control.signal_synth import SignalSpec, synthesize
+from scpi_control import exceptions, signal_synth
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+from scpi_control.signal_synth import SignalSpec, make_waveform, synthesize
 
 RATE = 100_000.0
 N = 4_000
@@ -21,6 +22,7 @@ def test_new_fields_default_to_off():
     assert spec.drift_amplitude == 0.0
     assert spec.glitch_rate == 0.0
     assert spec.ringing_frequency == 0.0
+    assert spec.jitter_rms == 0.0
 
 
 def test_default_spec_output_is_unchanged_by_the_new_fields():
@@ -43,6 +45,7 @@ def test_default_spec_output_is_unchanged_by_the_new_fields():
         {"glitch_amplitude": -1.0},
         {"ringing_damping": -1.0},
         {"ringing_frequency": -1.0},
+        {"jitter_rms": -1.0},
     ],
 )
 def test_negative_impairment_parameters_are_rejected(kwargs):
@@ -236,3 +239,261 @@ def test_ringing_is_continuous_across_stream_chunks():
     contiguous = synthesize(spec, RATE, N)
     streamed = np.concatenate(list(stream(spec, RATE, 1_000, duration=N / RATE)))
     np.testing.assert_array_equal(streamed, contiguous)
+
+
+# --- jitter_rms -------------------------------------------------------------
+#
+# Each cycle gets an independent Gaussian time-shift and the whole cycle moves
+# by it (see SignalSpec.jitter_rms and the design doc). Calibrated so
+# jitter_rms IS the value WaveformAnalyzer's own period-jitter measurement
+# reports back (sigma = jitter_rms / sqrt(2) internally).
+
+
+def test_jitter_rms_defaults_to_off():
+    spec = SignalSpec(kind="sine", frequency=1_000.0)
+    assert spec.jitter_rms == 0.0
+
+
+@pytest.mark.parametrize("kind", ["sine", "square"])
+def test_default_jitter_rms_produces_the_exact_clean_signal(kind):
+    """Zero-default regression. jitter_rms=0.0 (the default) must not perturb
+    the time array the generator sees at all: _apply_jitter's fast path
+    returns the SAME array object unchanged, so the output must match a
+    hand-derived closed-form reference exactly, not merely approximately --
+    proof this feature is a true no-op when disabled, not just a small one.
+
+    t0=0.0 (the default) keeps every sample away from a cycle-boundary float
+    residual (see test_cycle_boundary.py), so the closed form needs no
+    snapping logic of its own to match.
+    """
+    spec = SignalSpec(kind=kind, frequency=1_000.0, amplitude=1.0, seed=7)
+    out = synthesize(spec, RATE, N)
+    t = np.arange(N) / RATE
+    if kind == "sine":
+        expected = np.sin(2.0 * np.pi * 1_000.0 * t)
+    else:
+        # RATE/frequency = 100 samples per cycle, 50 high then 50 low (duty=0.5).
+        expected = np.where((np.arange(N) % 100) < 50, 1.0, -1.0)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_jitter_moves_the_measured_period_jitter_off_zero():
+    """Before this: nothing in the codebase could make
+    WaveformAnalyzer.calculate_quality_stats report nonzero jitter. A clean
+    (unjittered) periodic signal must read as EXACTLY zero jitter here (not
+    merely "near" zero) -- proving the control is actually clean -- and
+    enabling jitter_rms must move it well off that floor.
+
+    "triangle", not "sine": see
+    test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolerance
+    for why sine's rising zero-crossing is the wrong kind to measure jitter on
+    with this analyzer. At RATE=100_000/frequency=1_000 (an exact 100
+    samples/cycle), the clean triangle's ascending v50 crossing lands on the
+    identical sample index every cycle -- period is a constant integer, so
+    std(periods) is exactly 0.0, not just small.
+    """
+    spec_clean = SignalSpec(kind="triangle", frequency=1_000.0, amplitude=1.0, seed=4)
+    spec_jittered = SignalSpec(kind="triangle", frequency=1_000.0, amplitude=1.0, jitter_rms=5e-6, seed=4)
+    clean_jitter = WaveformAnalyzer.calculate_quality_stats(make_waveform(spec_clean, RATE, N))["jitter"]
+    jittered_jitter = WaveformAnalyzer.calculate_quality_stats(make_waveform(spec_jittered, RATE, N))["jitter"]
+    assert clean_jitter == 0.0
+    assert jittered_jitter is not None and jittered_jitter > 1e-6
+
+
+def test_jitter_rms_matches_the_measured_period_jitter_within_statistical_tolerance():
+    """The calibration this feature exists to prove: WaveformAnalyzer's own
+    period-jitter measurement (calculate_quality_stats -- std(diff(rising-edge
+    sample indices)) * dt, the standard random-jitter definition) on a
+    jittered signal must come back close to the INJECTED jitter_rms, not
+    merely internally self-consistent with this module's own math.
+
+    Deliberately "triangle", not "sine" -- verified empirically, not assumed:
+    a sine's rising zero-crossing sits EXACTLY at fraction 0, the cycle wrap
+    where this feature's own per-cycle delta discontinuity lands (delta[n] is
+    used for every sample up to the wrap, delta[n+1] immediately after it).
+    Right at that steepest-slope point, a jump of |delta[n+1]-delta[n]|
+    comparable to one sample period can make the discretized sine
+    non-monotonic through the v50 threshold, producing a SPURIOUS extra
+    "rising edge" a couple of samples after the real one (reproduced: at
+    jitter_rms=1e-6 s here, sine gave 22/522 anomalous 2-6-sample "periods",
+    inflating measured jitter to ~20x the injected value). "triangle"'s
+    ascending v50 crossing sits at fraction 0.25 -- entirely inside one cycle,
+    using that cycle's single delta uniformly, nowhere near the fraction-0
+    wrap -- so the same delta discontinuity never lands anywhere close to the
+    measurement point (reproduced clean: 0 anomalous periods up to
+    jitter_rms=1e-5 s at this rate; the same 1e-6 s case that broke sine
+    measured ratio 1.08).
+
+    RATE=1 MHz, frequency=10 kHz -> 100 samples/cycle; N=50_000 -> 500 cycles,
+    so calculate_quality_stats sees ~499 measured periods. Treating those as
+    approximately independent (a mild overstatement of precision, since
+    adjacent periods share one delta term, but conservative given the
+    generous tolerance below), the standard error of a sample std-dev
+    estimate is sigma/sqrt(2*(n-1)) = jitter_rms/sqrt(2*498) ~= 3.2% of
+    jitter_rms. jitter_rms=3e-6 s is 3 samples (dt=1e-6 s), comfortably above
+    the edge-detector's dt/sqrt(12) ~= 2.9e-7 s quantization floor. A +/-25%
+    relative tolerance is >7 standard errors, comfortably ruling out random
+    flakiness while still catching a wrong calibration constant -- a missing
+    sqrt(2) would read ~41% high or ~29% low, both well outside this band.
+    Measured 1.0024x the injected value with these exact parameters.
+    """
+    rate = 1_000_000.0
+    n = 50_000
+    jitter_rms = 3e-6
+    spec = SignalSpec(kind="triangle", frequency=10_000.0, amplitude=1.0, jitter_rms=jitter_rms, seed=21)
+    waveform = make_waveform(spec, rate, n)
+    measured = WaveformAnalyzer.calculate_quality_stats(waveform)["jitter"]
+    assert measured is not None
+    assert measured == pytest.approx(jitter_rms, rel=0.25)
+
+
+def test_jitter_is_reproducible_under_a_seed():
+    spec = SignalSpec(kind="sine", frequency=1_000.0, jitter_rms=2e-5, seed=17)
+    np.testing.assert_array_equal(synthesize(spec, RATE, N), synthesize(spec, RATE, N))
+
+
+def test_jitter_differs_across_seeds():
+    base = dict(kind="sine", frequency=1_000.0, jitter_rms=2e-5)
+    a = synthesize(SignalSpec(seed=17, **base), RATE, N)
+    b = synthesize(SignalSpec(seed=18, **base), RATE, N)
+    assert not np.array_equal(a, b)
+
+
+def test_jitter_is_a_no_op_on_kinds_without_a_stable_period():
+    """PERIODIC_KINDS excludes "dc" (no cycle structure at all), "noise" (ditto),
+    and "chirp" (frequency sweeps, so "cycle index" is undefined). jitter_rms
+    must not raise or change their output."""
+    dc_clean = synthesize(SignalSpec(kind="dc", offset=0.5, seed=1), RATE, N)
+    dc_jittered = synthesize(SignalSpec(kind="dc", offset=0.5, jitter_rms=1e-5, seed=1), RATE, N)
+    np.testing.assert_array_equal(dc_clean, dc_jittered)
+
+    chirp_clean = synthesize(SignalSpec(kind="chirp", frequency=1_000.0, seed=1), RATE, N)
+    chirp_jittered = synthesize(SignalSpec(kind="chirp", frequency=1_000.0, jitter_rms=1e-5, seed=1), RATE, N)
+    np.testing.assert_array_equal(chirp_clean, chirp_jittered)
+
+
+def test_jitter_shifts_where_ringing_anchors():
+    """Jitter warps time BEFORE ringing's own edge detection runs (both the
+    plain call and, inside the ringing branch, the extended-window call), so
+    ringing keys on the ACTUAL jittered edge, not the nominal grid position --
+    the physically-correct behaviour the design doc calls out as needing no
+    special-casing in the ringing code path itself.
+
+    signal_synth._jitter_cycle_rng(seed, 0) is called directly to obtain
+    cycle 0's delta -- this is ground truth precisely because it is the same
+    seeded-generator call synthesize() itself makes internally for that cycle,
+    not an independent re-derivation of the math. ringing_damping=200_000 (vs.
+    the module's usual 5_000) is deliberate: it shrinks the decay kernel to
+    ~25 samples so the ring stays local to its own edge and cannot spill into
+    -- or be confused with -- ringing from a neighbouring cycle's edge.
+    """
+    rate = 1_000_000.0
+    n = 4_000
+    frequency = 1_000.0  # 1000 samples/cycle at this rate
+    jitter_rms = 5e-5  # 50 us: several tens of samples of expected shift
+    seed = 9
+    base = dict(kind="square", frequency=frequency, amplitude=1.0, seed=seed)
+
+    clean = synthesize(SignalSpec(**base), rate, n)
+    rung_jittered = synthesize(SignalSpec(jitter_rms=jitter_rms, ringing_frequency=50_000.0, ringing_damping=200_000.0, **base), rate, n)
+
+    sigma = jitter_rms / np.sqrt(2.0)
+    delta0 = signal_synth._jitter_cycle_rng(seed, 0).normal(0.0, sigma)
+    # Cycle 0's own falling (duty-threshold) edge is nominally at sample 500
+    # (duty * samples-per-cycle = 0.5 * 1000) and, being entirely inside
+    # cycle 0, shifts by cycle 0's own delta alone.
+    predicted_edge = 500 + delta0 * rate
+
+    nominal_falling = np.flatnonzero(np.diff(clean) < 0)[0] + 1
+    assert nominal_falling == 500, "sanity check on the nominal edge position"
+    assert abs(predicted_edge - 500) > 30, "test parameters should produce a shift large enough to be unambiguous -- widen jitter_rms if this ever fails"
+
+    # Search a window centered on the PREDICTED position, not a blind scan of
+    # the whole cycle -- ringing's own damped oscillation produces many small
+    # sample-to-sample sign flips as it decays, so "first negative diff
+    # anywhere" is not a safe way to find the real transition once ringing is
+    # on; anchoring the search to the predicted location is.
+    lo = int(predicted_edge) - 30
+    falling_in_window = np.flatnonzero(np.diff(rung_jittered[lo : lo + 60]) < 0)
+    assert falling_in_window.size > 0, "expected a falling edge near the predicted jittered position"
+    actual_edge = lo + falling_in_window[0] + 1
+
+    assert actual_edge == pytest.approx(predicted_edge, abs=2.0), "the edge must land at the jittered position, not the nominal grid position 500"
+
+    # And the ring itself (an edge impairment) must be anchored at that ACTUAL
+    # edge: the samples right after it should show much more oscillation than
+    # the same-width window sitting at the now-wrong nominal position 500,
+    # where (with this short a decay kernel) the ring has already fully died
+    # out by the time cycle 0's real transition happens elsewhere.
+    ring_at_actual = rung_jittered[actual_edge : actual_edge + 15]
+    ring_at_nominal = rung_jittered[500:515]
+    assert np.std(ring_at_actual) > 0.1
+    assert np.std(ring_at_nominal) == 0.0, "sanity check: this short ringing kernel should have fully settled by the (now-empty) nominal edge position"
+
+
+def test_jitter_across_a_stream_chunk_boundary_is_a_pinned_known_limitation():
+    """Documents (does not hide) the design's accepted "Known limitation":
+    stream() bumps spec.seed by chunk_index per chunk (existing, deliberate
+    behaviour -- see stream()'s own docstring). A cycle that straddles a
+    stream() chunk boundary is rendered by TWO different synthesize() calls --
+    one per chunk -- each using a different seed, so
+    _jitter_cycle_rng(seed, cycle) draws a DIFFERENT, uncorrelated delta for
+    the SAME cycle depending on which half of it is being rendered.
+
+    This is NOT merely "the jump at this boundary looks bigger than average":
+    a jump between one cycle and the next is EXPECTED and normal everywhere in
+    this model (that is what produces jitter's period variation in the first
+    place -- see SignalSpec.jitter_rms), so an ordinary between-cycle jump is
+    no evidence of anything wrong. The actual defect is narrower: a
+    within-cycle inconsistency where two samples that belong to the SAME
+    nominal cycle (cyc_before == cyc_after below) get shifted by two DIFFERENT
+    deltas, only because stream() happened to cut the buffer there. This test
+    pins that precisely by reproducing, from the seeded generators directly,
+    exactly which two deltas produced the streamed samples on either side of
+    each chunk boundary -- and contrasting that with `contiguous`, where the
+    same cycle uses a SINGLE delta (spec.seed, unbumped) throughout, so it has
+    no such inconsistency.
+
+    frequency=997.0 and chunk_size=1_000 (as in the ringing continuity test
+    above) put a chunk boundary in the middle of most cycles, not on one.
+    """
+    from scpi_control.signal_synth import stream
+
+    spec = SignalSpec(kind="sine", frequency=997.0, amplitude=1.0, jitter_rms=3e-5, seed=2)
+    contiguous = synthesize(spec, RATE, N)
+    streamed = np.concatenate(list(stream(spec, RATE, 1_000, duration=N / RATE)))
+    assert not np.array_equal(streamed, contiguous), "stream()'s per-chunk seed bump must actually change jittered output vs. one contiguous call"
+
+    sigma = spec.jitter_rms / np.sqrt(2.0)
+    dt = 1.0 / RATE
+    chunk_size = 1_000
+    boundaries_straddling_one_cycle = 0
+    for b in (1_000, 2_000, 3_000):
+        t_before, t_after = (b - 1) * dt, b * dt
+        cyc_before = int(np.floor(spec.frequency * t_before))
+        cyc_after = int(np.floor(spec.frequency * t_after))
+        if cyc_before != cyc_after:
+            continue  # this particular boundary happened to land exactly on a cycle wrap -- nothing to pin
+        boundaries_straddling_one_cycle += 1
+
+        chunk_before, chunk_after = (b - 1) // chunk_size, b // chunk_size
+        delta_before = signal_synth._jitter_cycle_rng(spec.seed + chunk_before, cyc_before).normal(0.0, sigma)
+        delta_after = signal_synth._jitter_cycle_rng(spec.seed + chunk_after, cyc_after).normal(0.0, sigma)
+        assert delta_before != delta_after, "the whole point of the limitation: the SAME cycle drew two different deltas"
+
+        # The streamed reconstruction must match the TWO-delta (inconsistent)
+        # prediction, sample for sample.
+        predicted_before = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_before - delta_before) + spec.phase)
+        predicted_after = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_after - delta_after) + spec.phase)
+        assert streamed[b - 1] == pytest.approx(predicted_before, abs=1e-9)
+        assert streamed[b] == pytest.approx(predicted_after, abs=1e-9)
+
+        # Whereas the single contiguous call used ONE delta (unbumped
+        # spec.seed) for this entire cycle -- no within-cycle jump.
+        delta_whole_cycle = signal_synth._jitter_cycle_rng(spec.seed, cyc_before).normal(0.0, sigma)
+        predicted_contiguous_before = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_before - delta_whole_cycle) + spec.phase)
+        predicted_contiguous_after = spec.amplitude * np.sin(2 * np.pi * spec.frequency * (t_after - delta_whole_cycle) + spec.phase)
+        assert contiguous[b - 1] == pytest.approx(predicted_contiguous_before, abs=1e-9)
+        assert contiguous[b] == pytest.approx(predicted_contiguous_after, abs=1e-9)
+
+    assert boundaries_straddling_one_cycle > 0, "test setup should produce at least one boundary that actually straddles a single cycle"

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -61,7 +61,7 @@ def test_the_new_fields_are_appended_and_do_not_move_the_existing_ones():
         "ringing_frequency",
         "ringing_damping",
     ]
-    assert names[14:] == ["end_frequency", "sweep_time", "sweep_log", "tau", "pulse_width", "edge_time", "harmonics"]
+    assert names[14:] == ["end_frequency", "sweep_time", "sweep_log", "tau", "pulse_width", "edge_time", "harmonics", "jitter_rms"]
 
 
 def _bin_amplitudes(samples, rate):


### PR DESCRIPTION
## Summary

Adds timing/period jitter to the mock signal-synthesis engine — `SignalSpec` gains a new `jitter_rms` field (seconds, default `0.0` = off) that injects period-to-period timing jitter into synthesized signals, giving `WaveformAnalyzer`'s existing jitter measurement (`std(diff(edge_indices)) * dt`, the standard "random jitter" definition) something real to measure for the first time.

- Applies to `PERIODIC_KINDS` only (sine, square, triangle, ramp, multitone, exponential, pulse); no-op on `dc`/`noise` (no cycle structure) and `chirp` (no stable period).
- Each cycle boundary draws an independent Gaussian time-shift; every sample's shift is the linear interpolation between the two boundaries straddling it — a continuous time warp, not a per-cycle hard step. Composes correctly with `ringing_frequency` (rings at the actual jittered edge, no special-casing needed).
- **Calibration is fraction-dependent, and that's real, not a bug:** for kinds whose measured (rising v50) edge sits at the cycle boundary — `sine`, `square`, `multitone`, `pulse`, all the common defaults — measured jitter matches `jitter_rms` almost exactly (verified ~0.94–1.08 across trials). For `triangle`/`ramp`, whose measured edge sits mid-cycle, measured jitter is a smaller, stable, documented fraction (~0.66–0.68 / ~0.50–0.54). Full derivation and per-kind table in `docs/superpowers/specs/2026-08-28-signal-timing-jitter-design.md`.
- **Known limitation, stated plainly, not buried:** `stream()` bumps its seed per chunk (existing, deliberate behavior), so a cycle straddling a `stream()` chunk boundary gets two different jitter draws — a small, bounded discontinuity affecting at most that one cycle. Single `synthesize()`/`make_waveform()` calls (mock oscilloscope queries, essentially all test/example usage) are unaffected. True stream-continuity for jitter is intentionally a separate next feature, not bundled here.

## Notes for reviewers

This branch went through a real mid-implementation design revision, which is worth knowing before reading the diff:

1. First implementation (`c3491fb`) used a hard per-cycle step warp. A dedicated review found this made the warped time axis non-monotonic at *ordinary* jitter values (1% of period), causing spurious double-edge detection and 10-30x measurement inflation on 5 of 7 supported kinds — including `sine`, the default. Not a narrow edge case.
2. Fixed properly, not just documented around, per explicit direction: `109887b` replaced the hard step with continuous whole-cycle interpolation, raising the failure threshold from "one sample" to "roughly one period" and closing the gap for realistic values. A second independent review re-derived and re-measured every claim in this fix from scratch (including a real self-correction about where `ramp`'s measured edge actually sits) and found it solid.
3. A whole-branch review (the final gate) then caught one accuracy issue: the shipped docs/CHANGELOG claimed `pulse`'s calibration was "verified empirically" when it had never actually been tested — the design doc itself only said "expected." Rather than soften the wording, `0a3c60f` added the missing test; the claim held up (~0.95–1.03), so the code/CHANGELOG text needed no change, just a real test behind it.

Every commit here was independently reviewed (not self-reported) before the next one landed.

## Test plan

- [x] `pytest -m "not slow" -n 8` — 2920 passed, 60 skipped, clean
- [x] `pytest tests/` (full suite, no marker filter — this repo's milestone convention) — 2954 passed, 60 skipped, clean
- [x] `black --check --line-length 200 scpi_control/ examples/` — clean
- [x] `flake8 scpi_control/ --count --select=E9,F63,F7,F82` — clean
- [x] `diff CHANGELOG.md docs/about/changelog.md` — empty (mandatory mirror)
- [x] `examples/synthetic_signals.py` runs end-to-end, no hardware, prints a sane injected-vs-measured jitter comparison (2.91µs measured vs 3.00µs injected)
