### PR TITLE
feat: waveform superposition for mock signal synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ pip install "SCPI-Instrument-Control[all]"   # everything below
 | `[usb]` | USB-TMC, GPIB, and serial instruments via PyVISA |
 | `[hdf5]` | `.h5` waveform export |
 | `[fun]` | Vector graphics / XY-mode drawing |
+| `[mock]` | Nothing new -- names the mock/synthetic-signal tooling already in core, for discoverability |
 
 Requires Python 3.9+. The core install needs only NumPy, SciPy, and Matplotlib.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,12 @@ usb = [
 experimental = [
     # Future experimental features will be added here
 ]
+mock = [
+    # Mock/synthetic-signal tooling (signal_synth, connection.mock, dut) ships
+    # in the core install already -- this extra exists so a user who only
+    # wants the mock tooling has a discoverable, intention-revealing install
+    # command, e.g. pip install "SCPI-Instrument-Control[mock]".
+]
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -18,7 +18,7 @@ from scpi_control.models import detect_model_from_idn
 if TYPE_CHECKING:
     import numpy as np
 
-    from scpi_control.signal_synth import SignalSpec
+    from scpi_control.signal_synth import SignalSpec, SuperposedSignal
 
 _PERSONALITIES = {
     "siglent": siglent,
@@ -74,7 +74,7 @@ class MockConnection(BaseConnection):
         # response the mock could not otherwise produce -- e.g. one with no
         # block header, to prove a BLOCK declaration against it is rejected.
         mock_raw_response: Optional[bytes] = None,
-        signals: Optional[Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]]] = None,
+        signals: Optional[Dict[int, Union["SignalSpec", "SuperposedSignal", Callable[[], "SignalSpec"]]]] = None,
         sample_rate: float = 1_000.0,
         timebase: float = 1e-3,
         trigger_status: Optional[List[str]] = None,
@@ -129,7 +129,7 @@ class MockConnection(BaseConnection):
         # underscore-prefixed) because tests set it directly, mid-test, after
         # the write() that would otherwise select a response.
         self.mock_raw_response: Optional[bytes] = mock_raw_response
-        self._signals: Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]] = dict(signals) if signals else {}
+        self._signals: Dict[int, Union["SignalSpec", "SuperposedSignal", Callable[[], "SignalSpec"]]] = dict(signals) if signals else {}
         self._acquisition_counts: Dict[int, int] = {}
         # Coupling default is dialect-specific: modern wire vocabulary is
         # {DC,AC,GND} (scpi_commands.py's _COUPLING_FROM_WIRE); legacy/LeCroy

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -9,10 +9,11 @@ does not model offset (include_offset=False).
 """
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 import numpy as np
 
+from scpi_control import exceptions
 from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, SuperposedSignal, synthesize, synthesize_combined
 
 if TYPE_CHECKING:
@@ -65,7 +66,13 @@ def _trigger_crossing(spec: SignalSpec, level: float, rising: bool) -> Optional[
     return float(indices[0] + 1) * (period / n)
 
 
-def spec_for(conn: "MockConnection", channel: int) -> SignalSpec:
+# Sentinel distinguishing "no source given, look it up" from "source is None"
+# (a channel with nothing configured is a legitimate, common case that must
+# still resolve to a default spec below).
+_UNRESOLVED = object()
+
+
+def spec_for(conn: "MockConnection", channel: int, source: Any = _UNRESOLVED) -> SignalSpec:
     """The signal a channel 'sees': user-specified, else the channel default.
 
     A stored value is either a SignalSpec or a zero-argument callable returning
@@ -74,11 +81,33 @@ def spec_for(conn: "MockConnection", channel: int) -> SignalSpec:
     captures between captures. Everything downstream (point_count, raw_volts, the
     trigger-crossing search, the three vendor personalities) keeps receiving a
     plain SignalSpec and never learns the difference.
+
+    Does NOT handle SuperposedSignal: a channel's stored value can also be a
+    SuperposedSignal (raw_volts' own combined-signal branch), which has no
+    single SignalSpec to hand back. Callers must check for that case
+    themselves -- via `isinstance(source, SuperposedSignal)` -- BEFORE calling
+    this function, exactly as raw_volts() does upstream of its call here. If a
+    SuperposedSignal reaches this function anyway, it raises rather than
+    silently handing one back where a SignalSpec was promised.
+
+    Args:
+        source: The already-resolved `conn._signals.get(channel)` value, when
+            a caller has one on hand (raw_volts does, to avoid looking the
+            dict up twice per acquisition). Omit to have this function do the
+            lookup itself.
+
+    Raises:
+        exceptions.InvalidParameterError: if the resolved value is a
+            SuperposedSignal.
     """
-    source = conn._signals.get(channel)
+    if source is _UNRESOLVED:
+        source = conn._signals.get(channel)
     if source is None:
         return _DEFAULT_SPECS.get(channel, _FALLBACK_SPEC)
-    return source() if callable(source) else source
+    resolved = source() if callable(source) else source
+    if isinstance(resolved, SuperposedSignal):
+        raise exceptions.InvalidParameterError(f"channel {channel} is configured with a SuperposedSignal, which has no single SignalSpec -- check for SuperposedSignal before calling spec_for()")
+    return resolved
 
 
 def point_count(conn: "MockConnection", channel: int) -> int:
@@ -88,6 +117,44 @@ def point_count(conn: "MockConnection", channel: int) -> int:
         return len(explicit)
     window = DIVISIONS * conn.timebase
     return max(2, min(MAX_POINTS, int(round(conn.sample_rate * window))))
+
+
+def _bump_seed(spec: SignalSpec, count: int) -> SignalSpec:
+    """Advance `spec.seed` by the acquisition count, unless it's None (fresh
+    randomness every call -- a seed of None + count is still None, so there's
+    nothing to bump)."""
+    return spec if spec.seed is None else replace(spec, seed=spec.seed + count)
+
+
+def _render_with_dut(render: Callable[[int, float], np.ndarray], dut: Optional[Any], sample_rate: float, n: int, t0: float) -> np.ndarray:
+    """Render `n` samples starting at `t0`, running them through `dut` (if any).
+
+    `render(n_points, t0)` synthesizes exactly that many seed-bumped samples --
+    a thunk over synthesize() or synthesize_combined() plus whatever spec/
+    SuperposedSignal the caller already bumped, so this helper stays agnostic
+    to which one is in play.
+
+    A DUT filter is STATEFUL, unlike every generator in signal_synth. Filtering
+    the bare capture would start from y=0 and put a settling transient at the
+    head of every acquisition, so when a dut is given, a lead-in is rendered
+    BEFORE t0, the whole extended window is filtered, and the lead-in is
+    sliced back off -- the same fix, for the same reason, as the ringing
+    impairment's pre-t0 window (signal_synth.py's ringing branch).
+
+    Note the extended t0 is computed as a subtraction (`t0 - warmup /
+    sample_rate`) rather than by shifting the index range the way the ringing
+    path does, so the sample at index `warmup` can land a few ULP from `t0`.
+    That is deliberate: the output is low-pass filtered and then quantized, and
+    the relevant grid -- the FINER of the two callers feeding this function --
+    is many orders of magnitude coarser than a sub-femtosecond timebase
+    difference. See dut._WARMUP_TIME_CONSTANTS for the measured numbers behind
+    the lead-in's depth.
+    """
+    if dut is None:
+        return render(n, t0)
+    warmup = dut.warmup_samples(sample_rate)
+    extended = render(n + warmup, t0 - warmup / sample_rate)
+    return dut.apply(extended, sample_rate)[warmup:]
 
 
 def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = None) -> np.ndarray:
@@ -128,51 +195,33 @@ def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = 
         # count-based rule the single-spec path applies below, then the
         # per-acquisition components are recombined into a new SuperposedSignal
         # so synthesize_combined() sees the bumped seeds.
-        per_acquisition_components = tuple(component if component.seed is None else replace(component, seed=component.seed + count) for component in source.components)
+        per_acquisition_components = tuple(_bump_seed(component, count) for component in source.components)
         per_acquisition = replace(source, components=per_acquisition_components)
-        # NOT the getattr(conn._signals.get(channel), "dut", None) lookup the
-        # single-spec path uses below: that reads the same object here too
-        # (a SuperposedSignal is never wrapped in a callable), but `source`
-        # is already resolved above, so read `.dut` off it directly.
-        dut = source.dut
-        if dut is None:
-            return synthesize_combined(per_acquisition, conn.sample_rate, n, t0=t0)
-        # See the single-spec DUT branch below for why a lead-in is rendered
-        # and sliced off; the only difference here is synthesize_combined()
-        # sums every component over that same extended window before filtering.
-        warmup = dut.warmup_samples(conn.sample_rate)
-        extended = synthesize_combined(per_acquisition, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
-        return dut.apply(extended, conn.sample_rate)[warmup:]
+        # `source` is already resolved above (a SuperposedSignal is never
+        # wrapped in a callable), so read `.dut` off it directly.
+        return _render_with_dut(
+            lambda n_, t0_: synthesize_combined(per_acquisition, conn.sample_rate, n_, t0=t0_),
+            source.dut,
+            conn.sample_rate,
+            n,
+            t0,
+        )
 
-    spec = spec_for(conn, channel)
+    spec = spec_for(conn, channel, source)
     crossing = _trigger_crossing(spec, conn.trigger_level.get(channel, 0.0), _is_rising(conn.trigger_slope))
     if crossing is not None:
         t0 = crossing - (n / conn.sample_rate) / 2.0  # center of the SAMPLED span (may be shorter than the nominal window when MAX_POINTS clamps)
     else:
         t0 = count * window * _DRIFT_FRACTION  # untriggerable: free-run drift
-    per_acquisition = spec if spec.seed is None else replace(spec, seed=spec.seed + count)
-    dut = getattr(conn._signals.get(channel), "dut", None)
-    if dut is None:
-        return synthesize(per_acquisition, conn.sample_rate, n, t0=t0)
-    # A DUT filter is STATEFUL, unlike every generator in signal_synth. Filtering
-    # the bare capture would start from y=0 and put a settling transient at the
-    # head of every acquisition, so render a lead-in BEFORE t0, filter across the
-    # whole extended window, then slice the lead-in off -- the same fix, for the
-    # same reason, as the ringing impairment's pre-t0 window (signal_synth.py:381).
-    #
-    # Note the extended t0 is computed as a subtraction rather than by shifting
-    # the index range the way the ringing path does, so the sample at index
-    # `warmup` can land a few ULP from `t0`. That is deliberate here: the output
-    # is low-pass filtered and then quantized. The relevant grid is the FINER of
-    # the two this function feeds -- not the int8 path's 25 codes/div (~0.04 V at
-    # 1 V/div) but the modern dialect's WORD path at 6400 codes/div
-    # (siglent.py's _MODERN_CODE_PER_DIV_WORD), i.e. 0.15625 mV/LSB. A
-    # sub-femtosecond timebase difference is still many orders of magnitude below
-    # even that. The lead-in's DEPTH is sized against the same WORD grid rather
-    # than int8 -- see dut._WARMUP_TIME_CONSTANTS for the measured numbers.
-    warmup = dut.warmup_samples(conn.sample_rate)
-    extended = synthesize(per_acquisition, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
-    return dut.apply(extended, conn.sample_rate)[warmup:]
+    per_acquisition = _bump_seed(spec, count)
+    dut = getattr(source, "dut", None)
+    return _render_with_dut(
+        lambda n_, t0_: synthesize(per_acquisition, conn.sample_rate, n_, t0=t0_),
+        dut,
+        conn.sample_rate,
+        n,
+        t0,
+    )
 
 
 def payload_for(conn: "MockConnection", channel: int, *, include_offset: bool) -> bytes:

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 
-from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, synthesize
+from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, SuperposedSignal, synthesize, synthesize_combined
 
 if TYPE_CHECKING:
     from scpi_control.connection.mock.base import MockConnection
@@ -107,11 +107,40 @@ def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = 
             FULL record must still be synthesized as one call so a caller can
             slice consistent windows out of it afterwards.
     """
-    spec = spec_for(conn, channel)
+    source = conn._signals.get(channel)
     n = point_count(conn, channel) if n_override is None else n_override
     count = conn._acquisition_counts.get(channel, 0)
     conn._acquisition_counts[channel] = count + 1
     window = DIVISIONS * conn.timebase
+
+    if isinstance(source, SuperposedSignal):
+        # components[0] is the PRIMARY component: it alone drives trigger-level
+        # detection, exactly like the single-spec path below does with its one
+        # spec -- a SuperposedSignal has no single "kind", so _trigger_crossing
+        # cannot be asked about the combination as a whole.
+        primary = source.components[0]
+        crossing = _trigger_crossing(primary, conn.trigger_level.get(channel, 0.0), _is_rising(conn.trigger_slope))
+        if crossing is not None:
+            t0 = crossing - (n / conn.sample_rate) / 2.0  # center of the SAMPLED span (may be shorter than the nominal window when MAX_POINTS clamps)
+        else:
+            t0 = count * window * _DRIFT_FRACTION  # untriggerable: free-run drift
+        # Each component bumps its OWN seed independently by the same
+        # count-based rule the single-spec path applies below, then the
+        # per-acquisition components are recombined into a new SuperposedSignal
+        # so synthesize_combined() sees the bumped seeds.
+        per_acquisition_components = tuple(component if component.seed is None else replace(component, seed=component.seed + count) for component in source.components)
+        per_acquisition = replace(source, components=per_acquisition_components)
+        dut = source.dut  # NOT the getattr(conn._signals.get(channel), "dut", None) lookup below: for a bare SuperposedSignal that reads the same object, but a SuperposedSignal is never wrapped in a callable, so `source` (already resolved above) is the right place to read it from directly.
+        if dut is None:
+            return synthesize_combined(per_acquisition, conn.sample_rate, n, t0=t0)
+        # See the single-spec DUT branch below for why a lead-in is rendered
+        # and sliced off; the only difference here is synthesize_combined()
+        # sums every component over that same extended window before filtering.
+        warmup = dut.warmup_samples(conn.sample_rate)
+        extended = synthesize_combined(per_acquisition, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
+        return dut.apply(extended, conn.sample_rate)[warmup:]
+
+    spec = spec_for(conn, channel)
     crossing = _trigger_crossing(spec, conn.trigger_level.get(channel, 0.0), _is_rising(conn.trigger_slope))
     if crossing is not None:
         t0 = crossing - (n / conn.sample_rate) / 2.0  # center of the SAMPLED span (may be shorter than the nominal window when MAX_POINTS clamps)

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -130,7 +130,11 @@ def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = 
         # so synthesize_combined() sees the bumped seeds.
         per_acquisition_components = tuple(component if component.seed is None else replace(component, seed=component.seed + count) for component in source.components)
         per_acquisition = replace(source, components=per_acquisition_components)
-        dut = source.dut  # NOT the getattr(conn._signals.get(channel), "dut", None) lookup below: for a bare SuperposedSignal that reads the same object, but a SuperposedSignal is never wrapped in a callable, so `source` (already resolved above) is the right place to read it from directly.
+        # NOT the getattr(conn._signals.get(channel), "dut", None) lookup the
+        # single-spec path uses below: that reads the same object here too
+        # (a SuperposedSignal is never wrapped in a callable), but `source`
+        # is already resolved above, so read `.dut` off it directly.
+        dut = source.dut
         if dut is None:
             return synthesize_combined(per_acquisition, conn.sample_rate, n, t0=t0)
         # See the single-spec DUT branch below for why a lead-in is rendered

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -8,7 +8,7 @@ docs and tests; the mock coupling and code-conversion layers are kind-agnostic.
 
 import time
 from dataclasses import dataclass, replace
-from typing import Callable, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
 
 import numpy as np
 
@@ -164,6 +164,38 @@ class SignalSpec:
     # Appended after jitter_rms -- the current last field -- for the same
     # don't-reorder-positional-construction reason as every field above it.
     jitter_seed: Optional[int] = None  # decouples jitter's boundary RNG from `seed`; None falls back to `seed`. stream() auto-fills this with the pre-bump `seed` per chunk -- see the docstring above
+
+
+@dataclass(frozen=True)
+class SuperposedSignal:
+    """Two or more independently-synthesized signals summed into one trace.
+
+    Each component keeps its own full SignalSpec -- kind, impairments, seed --
+    and is synthesized in isolation; the combined waveform is their plain
+    elementwise sum, with no state shared between components. Useful for
+    modeling e.g. a tone riding on an independently-seeded noise floor, or two
+    unrelated tones summed onto one channel.
+
+    Attributes:
+        components: Two or more SignalSpecs to sum. synthesize_combined() and
+            make_waveform_combined() dispatch each one exactly as
+            synthesize()/make_waveform() would on its own, so a bad component
+            parameter surfaces as the same InvalidParameterError it always has.
+        dut: Optional device-under-test model (e.g. dut.RCLowPass), applied to
+            the SUMMED signal rather than to any one component. Mirrors
+            connection/mock/loopback.py's AwgLoopback.dut: stored here so a
+            caller can carry a DUT alongside a signal source, but only
+            connection/mock/synth.py's raw_volts actually applies it (it is
+            the only layer that knows the sample rate and can render the
+            filter's lead-in).
+    """
+
+    components: Tuple[SignalSpec, ...]
+    dut: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if len(self.components) < 2:
+            raise exceptions.InvalidParameterError(f"SuperposedSignal needs at least 2 components to combine, got {len(self.components)}")
 
 
 # How close to a whole cycle a sample may sit and still count as landing exactly
@@ -663,6 +695,31 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     return samples
 
 
+def synthesize_combined(signal: SuperposedSignal, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:
+    """Generate voltage samples for a SuperposedSignal: the sum of its components.
+
+    Each component is synthesized independently -- via synthesize(), so it
+    keeps its own full impairments (noise, drift, glitches, jitter, seed) -- and
+    the results are summed elementwise. No state is shared between components.
+    A bad component parameter is caught by synthesize()'s own _validate(), the
+    same way it always is; the SuperposedSignal itself was already validated at
+    construction (SuperposedSignal.__post_init__).
+
+    Args:
+        signal: The components to sum.
+        sample_rate: Samples per second.
+        n_points: Number of samples.
+        t0: Time of the first sample in seconds (shifts periodic signals).
+
+    Returns:
+        float64 voltage array of length n_points.
+    """
+    total = synthesize(signal.components[0], sample_rate, n_points, t0=t0)
+    for component in signal.components[1:]:
+        total = total + synthesize(component, sample_rate, n_points, t0=t0)
+    return total
+
+
 def stream(
     spec: SignalSpec,
     sample_rate: float,
@@ -740,5 +797,15 @@ def make_waveform(spec: SignalSpec, sample_rate: float, n_points: int, channel: 
     from scpi_control.waveform import WaveformData
 
     voltage = synthesize(spec, sample_rate, n_points)
+    time = np.arange(n_points) / sample_rate
+    return WaveformData(time=time, voltage=voltage, channel=channel, sample_rate=sample_rate)
+
+
+def make_waveform_combined(signal: SuperposedSignal, sample_rate: float, n_points: int, channel: int = 1):
+    """Generate a WaveformData from a SuperposedSignal, mirroring make_waveform()."""
+    # Function-level import: see make_waveform()'s identical import above.
+    from scpi_control.waveform import WaveformData
+
+    voltage = synthesize_combined(signal, sample_rate, n_points)
     time = np.arange(n_points) / sample_rate
     return WaveformData(time=time, voltage=voltage, channel=channel, sample_rate=sample_rate)

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -8,11 +8,14 @@ docs and tests; the mock coupling and code-conversion layers are kind-agnostic.
 
 import time
 from dataclasses import dataclass, replace
-from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Optional, Tuple, Union
 
 import numpy as np
 
 from scpi_control import exceptions
+
+if TYPE_CHECKING:
+    from scpi_control.waveform import WaveformData
 
 
 @dataclass(frozen=True)
@@ -801,7 +804,7 @@ def make_waveform(spec: SignalSpec, sample_rate: float, n_points: int, channel: 
     return WaveformData(time=time, voltage=voltage, channel=channel, sample_rate=sample_rate)
 
 
-def make_waveform_combined(signal: SuperposedSignal, sample_rate: float, n_points: int, channel: int = 1):
+def make_waveform_combined(signal: SuperposedSignal, sample_rate: float, n_points: int, channel: int = 1) -> "WaveformData":
     """Generate a WaveformData from a SuperposedSignal, mirroring make_waveform()."""
     # Function-level import: see make_waveform()'s identical import above.
     from scpi_control.waveform import WaveformData

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -424,3 +424,24 @@ def test_superposed_signal_dut_visibly_smooths_a_square_component():
     soft_scope.disconnect()
 
     assert np.max(np.abs(np.diff(filtered))) < np.max(np.abs(np.diff(unfiltered)))
+
+
+def test_spec_for_rejects_a_superposed_signal():
+    """spec_for()'s contract is a plain SignalSpec -- it was never taught about
+    SuperposedSignal, which raw_volts' own isinstance check keeps upstream of
+    every real call site. Calling spec_for() directly on a channel configured
+    with a SuperposedSignal must fail loudly (InvalidParameterError) rather
+    than silently handing back a SuperposedSignal where a SignalSpec was
+    promised."""
+    from scpi_control import exceptions
+    from scpi_control.connection.mock.synth import spec_for
+
+    signal = SuperposedSignal(
+        (
+            SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0),
+            SignalSpec(kind="dc", offset=0.1),
+        )
+    )
+    _, conn = _scope(signals={1: signal})
+    with pytest.raises(exceptions.InvalidParameterError):
+        spec_for(conn, 1)

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -7,7 +7,7 @@ import pytest
 
 from scpi_control.connection import MockConnection
 from scpi_control.oscilloscope import Oscilloscope
-from scpi_control.signal_synth import SignalSpec
+from scpi_control.signal_synth import SignalSpec, SuperposedSignal, synthesize_combined
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
 MODERN_IDN = "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12"
@@ -308,3 +308,119 @@ def test_a_ringing_trigger_aligned_kind_still_displays_stably():
     second = scope.get_waveform(1, provenance=False)
     scope.disconnect()
     np.testing.assert_array_equal(first.voltage, second.voltage)
+
+
+def test_superposed_signal_is_triggerable_via_its_primary_component():
+    """The primary (first) component alone drives trigger-crossing detection --
+    a noiseless periodic primary still gives a stable, repeatable capture even
+    with a second, unrelated component summed in, exactly like a plain
+    SignalSpec's own trigger-stability test above."""
+    signal = SuperposedSignal(
+        (
+            SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0),
+            SignalSpec(kind="dc", offset=0.1, noise_rms=0.0),
+        )
+    )
+    scope, _ = _scope(signals={1: signal})
+    scope.write("C1:TRLV 0.0")
+    first = scope.get_waveform(1, provenance=False)
+    second = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_array_equal(first.voltage, second.voltage)
+
+
+def test_superposed_signal_free_runs_when_the_primary_is_unattainable():
+    """The mirror image of the trigger test above: an unattainable trigger
+    level on the primary component free-runs the combined signal, same as a
+    plain SignalSpec (test_unattainable_level_free_runs)."""
+    signal = SuperposedSignal(
+        (
+            SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0),
+            SignalSpec(kind="dc", offset=0.1, noise_rms=0.0),
+        )
+    )
+    scope, _ = _scope(signals={1: signal})
+    scope.write("C1:TRLV 5.0")
+    a = scope.get_waveform(1, provenance=False)
+    b = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert not np.array_equal(a.voltage, b.voltage)
+
+
+def test_superposed_components_seed_independently_per_acquisition():
+    """Mirrors test_seeded_sequences_reproduce_across_connections: each
+    component's own seed must advance by the acquisition count independently,
+    so two connections built from the same SuperposedSignal reproduce the same
+    sequence, and consecutive acquisitions on one connection differ."""
+    signals = {
+        1: SuperposedSignal(
+            (
+                SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0, seed=11),
+                SignalSpec(kind="noise", amplitude=0.05, seed=21),
+            )
+        )
+    }
+    scope1, _ = _scope(signals=signals)
+    first_a = scope1.get_waveform(1, provenance=False)
+    second_a = scope1.get_waveform(1, provenance=False)
+    scope1.disconnect()
+    scope2, _ = _scope(signals=signals)
+    first_b = scope2.get_waveform(1, provenance=False)
+    second_b = scope2.get_waveform(1, provenance=False)
+    scope2.disconnect()
+    np.testing.assert_array_equal(first_a.voltage, first_b.voltage)
+    np.testing.assert_array_equal(second_a.voltage, second_b.voltage)
+    assert not np.array_equal(first_a.voltage, second_a.voltage)  # seed advances per acquisition
+
+
+def test_superposed_signal_dut_filters_the_summed_signal():
+    """A SuperposedSignal's dut is applied to the SUMMED signal (raw_volts'
+    combined branch), not to each component separately -- checked at
+    raw_volts's float64 precision (mirrors test_trigger_search_ignores_the_
+    impairments' style of importing internals directly), independently
+    reconstructing the expected sum-then-filter result via the public
+    synthesize_combined()/RCLowPass API rather than duplicating raw_volts'
+    own arithmetic."""
+    from scpi_control.connection.mock.synth import _trigger_crossing, raw_volts
+    from scpi_control.dut import RCLowPass
+
+    tone = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0)
+    dc = SignalSpec(kind="dc", offset=0.3, noise_rms=0.0)
+    dut = RCLowPass(cutoff_hz=5_000.0)
+    signal = SuperposedSignal((tone, dc), dut=dut)
+
+    scope, conn = _scope(signals={1: signal})
+    scope.write("C1:TRLV 0.0")
+    actual = raw_volts(conn, 1)
+    scope.disconnect()
+
+    n = len(actual)
+    crossing = _trigger_crossing(tone, 0.0, True)  # primary component drives the trigger search
+    t0 = crossing - (n / conn.sample_rate) / 2.0
+    warmup = dut.warmup_samples(conn.sample_rate)
+    extended = synthesize_combined(signal, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
+    expected = dut.apply(extended, conn.sample_rate)[warmup:]
+
+    np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-9)
+
+
+def test_superposed_signal_dut_visibly_smooths_a_square_component():
+    """Sanity check that the DUT branch above is actually exercised (not just
+    mathematically vacuous): with a DUT, a square-wave component's sharp edges
+    are visibly rounded, mirroring test_loopback_capture.py's
+    test_the_dut_visibly_rounds_a_square_wave."""
+    from scpi_control.connection.mock.synth import raw_volts
+    from scpi_control.dut import RCLowPass
+
+    components = (SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, noise_rms=0.0), SignalSpec(kind="dc", offset=0.3, noise_rms=0.0))
+    sharp_scope, sharp_conn = _scope(signals={1: SuperposedSignal(components)})
+    sharp_scope.write("C1:TRLV 0.0")
+    unfiltered = raw_volts(sharp_conn, 1)
+    sharp_scope.disconnect()
+
+    soft_scope, soft_conn = _scope(signals={1: SuperposedSignal(components, dut=RCLowPass(cutoff_hz=2_000.0))})
+    soft_scope.write("C1:TRLV 0.0")
+    filtered = raw_volts(soft_conn, 1)
+    soft_scope.disconnect()
+
+    assert np.max(np.abs(np.diff(filtered))) < np.max(np.abs(np.diff(unfiltered)))

--- a/tests/test_signal_synth.py
+++ b/tests/test_signal_synth.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from scpi_control import exceptions
-from scpi_control.signal_synth import SignalSpec, make_waveform, stream, synthesize
+from scpi_control.signal_synth import SignalSpec, SuperposedSignal, make_waveform, make_waveform_combined, stream, synthesize, synthesize_combined
 
 
 def _dominant_frequency(voltage, sample_rate):
@@ -189,3 +189,43 @@ def test_stream_validates_at_call_time():
         stream(SignalSpec(), 1_000.0, 100, duration=-1.0)
     with pytest.raises(exceptions.InvalidParameterError):
         stream(SignalSpec(kind="sawtooth"), 1_000.0, 100)
+
+
+def test_superposed_dc_components_sum():
+    signal = SuperposedSignal((SignalSpec(kind="dc", offset=1.0), SignalSpec(kind="dc", offset=0.5)))
+    v = synthesize_combined(signal, 1_000.0, 100)
+    np.testing.assert_allclose(v, 1.5)
+
+
+def test_superposed_noise_reflects_the_noisy_components_variance():
+    quiet = SignalSpec(kind="dc", offset=0.0, noise_rms=0.0)
+    noisy = SignalSpec(kind="dc", offset=0.0, noise_rms=0.5, seed=1)
+    signal = SuperposedSignal((quiet, noisy))
+    v = synthesize_combined(signal, 1_000.0, 50_000)
+    assert np.std(v) == pytest.approx(0.5, rel=0.05)
+
+
+def test_superposed_independently_seeded_components_are_reproducible():
+    signal = SuperposedSignal(
+        (
+            SignalSpec(kind="sine", frequency=1_000.0, noise_rms=0.02, seed=5),
+            SignalSpec(kind="sine", frequency=3_000.0, noise_rms=0.02, seed=9),
+        )
+    )
+    a = synthesize_combined(signal, 1_000_000.0, 2_000)
+    b = synthesize_combined(signal, 1_000_000.0, 2_000)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_superposed_signal_requires_at_least_two_components():
+    with pytest.raises(exceptions.InvalidParameterError):
+        SuperposedSignal(components=(SignalSpec(),))
+
+
+def test_make_waveform_combined():
+    signal = SuperposedSignal((SignalSpec(kind="dc", offset=1.0), SignalSpec(kind="dc", offset=0.5)))
+    wf = make_waveform_combined(signal, sample_rate=100_000.0, n_points=2_000, channel=2)
+    assert wf.channel == 2
+    assert wf.sample_rate == pytest.approx(100_000.0)
+    assert wf.record_length == 2_000
+    np.testing.assert_allclose(wf.voltage, 1.5)


### PR DESCRIPTION
## Summary

- Adds waveform superposition to the mock signal-synthesis system: `scpi_control.signal_synth.SuperposedSignal` combines two or more independent `SignalSpec`s (e.g. a sine plus an unrelated noise/interference source) into one channel's signal, rather than the previous one-`SignalSpec`-per-channel model.
- `synthesize_combined(signal, sample_rate, n_points, t0=0.0)` sums `synthesize()` across every component — each keeps its own independent impairments/seed (a noisy interference component stays noisy and reproducible on its own terms). `make_waveform_combined()` mirrors `make_waveform()` on top of it.
- `MockConnection`'s `signals=` now accepts a `SuperposedSignal` per channel. Trigger-crossing detection uses the first component as the "primary" (matches real usage: trigger off your signal of interest, everything else is additive); per-acquisition seed bumping applies to each component independently; the existing DUT-filter feature (`RCLowPass`, etc.) now also applies to the *summed* signal when a `SuperposedSignal` carries a `dut`.
- Adds an empty `[mock]` pip extra, purely for discoverability — the mock/synthetic-signal tooling already ships in the core install; this just gives it a documented, intention-revealing install command.
- Review fixes folded in before merge: `spec_for()` now fails loudly (`InvalidParameterError`) instead of silently mistyping a `SuperposedSignal` as a `SignalSpec` if ever called on one directly; `raw_volts()`'s seed-bump/DUT-warmup/apply logic (previously duplicated across the single-spec and combined branches) is now shared via two small helpers; a redundant dict lookup on the per-capture hot path was removed; `make_waveform_combined()` gained its return type annotation.

## Test plan

- [x] `pytest tests/test_signal_synth.py tests/test_mock_synthesis.py tests/test_dut.py -v` — 83 passed
- [x] `pytest -m "not slow" -n 8` (broad suite) — 2965 passed, 61 skipped
- [x] `pytest tests/ -n 8` (full suite) — 3002 passed, 61 skipped
- [x] `black --check --line-length 200 scpi_control/` — clean
- [x] `flake8 scpi_control/ --count --select=E9,F63,F7,F82` — 0 errors
- [x] `python -c "from scpi_control.signal_synth import SuperposedSignal, synthesize_combined, make_waveform_combined"` — imports cleanly
