### PR TITLE
refactor: extract shared gallery-script driver into gallery_common.py

### DIFF
--- a/scripts/media/gallery_common.py
+++ b/scripts/media/gallery_common.py
@@ -1,0 +1,206 @@
+"""Shared rendering/writing primitives for the scripts/media/make_*_gallery_gifs.py scripts.
+
+Four sibling scripts (make_signal_gallery_gifs.py, make_superposition_gallery_gifs.py,
+make_clipping_gallery_gifs.py, make_distortion_gallery_gifs.py) each render a
+gallery of small looping scrolling-scope GIFs for the README, built from live
+`scpi_control.signal_synth.stream()` captures plotted with the report
+generator's own `PlotStyle`. They share one frame-rendering/GIF-writing
+pipeline, one seamless-loop verification routine, and one `main()` shape
+(build every table entry, seam-check it, write it, print a summary line).
+This module holds that shared code so it lives in exactly one place instead
+of being copy-pasted across the four scripts.
+
+This module is a library, not a runnable script: it has no `main()` and no
+`if __name__ == "__main__":` block. Each gallery script still owns its own
+table (KINDS/COMBOS/DEMOS) and its own per-table build function, since those
+genuinely differ script to script -- see each script's module docstring for
+what it contributes on top of this module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEST_DIR = REPO_ROOT / "docs" / "images"
+SIZE_BUDGET_KB = 450
+
+FIG_SIZE_IN = (3.4, 1.9)  # inches
+DPI = 100  # -> 340x190 px frames
+PALETTE_COLORS = 48  # a single line + grid on white needs far fewer colours than the code-editor GIFs
+
+# How close the buffer just after the LAST frame's chunk must land to the
+# FIRST frame's buffer, in volts, for a "seamless" kind (see KINDS below).
+# Tight: everything at play here (SignalSpec generators, t0 bookkeeping in
+# stream()/synthesize()) is deterministic float64 arithmetic with no jitter
+# or impairments enabled, so a genuinely aligned loop reproduces to within a
+# few ULPs, not merely "close". A few micro-volts already means the frame
+# math is wrong, not that the tolerance was too strict.
+SEAMLESS_TOLERANCE_V = 1e-6
+
+
+def _prime_buffer(gen, window_samples: int) -> np.ndarray:
+    """Fill the rolling buffer with whole stream() chunks before rendering starts."""
+    chunks = [next(gen)]
+    total = chunks[0].size
+    while total < window_samples:
+        chunk = next(gen)
+        chunks.append(chunk)
+        total += chunk.size
+    buffer = np.concatenate(chunks)
+    if buffer.size != window_samples:
+        raise RuntimeError(f"buffer priming landed on {buffer.size} samples, expected exactly {window_samples} -- window_samples must be a multiple of chunk_size")
+    return buffer
+
+
+def render_frame(t_ms: np.ndarray, voltage: np.ndarray, entry: Dict[str, Any], style) -> Image.Image:
+    """Render one rolling-buffer frame to an in-memory RGB image."""
+    fig = Figure(figsize=FIG_SIZE_IN, dpi=DPI)
+    fig.patch.set_facecolor(style.background_color)
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111)
+
+    ax.plot(t_ms, voltage, color=style.waveform_color, linewidth=style.waveform_linewidth)
+    style.apply_to_axes(ax)
+
+    ax.set_xlim(t_ms[0], t_ms[-1])
+    ax.set_ylim(*entry["ylim"])
+    ax.set_xlabel("Time (ms)", fontsize=style.label_fontsize)
+    ax.set_ylabel("Voltage (V)", fontsize=style.label_fontsize)
+    ax.set_title(entry["kind"], fontsize=style.title_fontsize)
+    fig.tight_layout()
+
+    canvas.draw()
+    w, h = canvas.get_width_height()
+    img = Image.frombuffer("RGBA", (w, h), canvas.buffer_rgba(), "raw", "RGBA", 0, 1)
+    return img.convert("RGB")
+
+
+def _check_seamless(entry: Dict[str, Any], first_buffer: np.ndarray, post_loop_buffer: np.ndarray) -> float:
+    """Empirically verify the wrap-around jump, in volts. Raises if too large."""
+    max_diff = float(np.max(np.abs(post_loop_buffer - first_buffer)))
+    if max_diff > SEAMLESS_TOLERANCE_V:
+        raise RuntimeError(
+            f"{entry['kind']!r} is marked seam_checked but the buffer after "
+            f"{entry['n_frames']} frames differs from the first frame by up to "
+            f"{max_diff:.3e} V (tolerance {SEAMLESS_TOLERANCE_V:.0e} V) -- the "
+            "loop would show a visible jump; check sample_rate/chunk_size/n_frames"
+        )
+    return max_diff
+
+
+def _write_gif(dest: Path, frames: list[Image.Image], durations: list[int]) -> float:
+    palettised = [f.convert("P", palette=Image.ADAPTIVE, colors=PALETTE_COLORS) for f in frames]
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.stem + ".tmp.gif")
+    try:
+        palettised[0].save(tmp, save_all=True, append_images=palettised[1:], duration=durations, loop=0, optimize=True, disposal=2)
+        size_kb = tmp.stat().st_size / 1024
+        if size_kb > SIZE_BUDGET_KB:
+            raise RuntimeError(f"{dest.name} is {size_kb:.0f} KB, over the {SIZE_BUDGET_KB} KB budget -- reduce frame count, dimensions, or palette depth")
+        os.replace(tmp, dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    return size_kb
+
+
+def title_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of `entry` guaranteed to carry a "kind" field, for render_frame/_check_seamless.
+
+    Both helpers were written for KINDS entries, where every entry already
+    has exactly one top-level "kind" and uses it as a frame title / in an
+    error message. This unifies the three near-identical `_title_entry()`
+    helpers that used to live separately in make_superposition_gallery_gifs.py,
+    make_clipping_gallery_gifs.py, and make_distortion_gallery_gifs.py: a
+    COMBOS entry sums two or more kinds and a DEMOS entry keeps "kind" nested
+    inside "spec", so neither has one top-level "kind" to use directly, and
+    both substitute a readable title derived from "name" instead.
+
+    A KINDS entry already has a top-level "kind" (it never needed a
+    `_title_entry()` of its own), so it is returned unchanged -- this
+    function is a safe pass-through for any entry shape, not just the ones
+    that need the substitution.
+    """
+    if "kind" in entry:
+        return entry
+    return {**entry, "kind": entry["name"].replace("_", " ")}
+
+
+def build_single_spec_demo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndarray]:
+    """Stream `entry`'s single SignalSpec and render its frames.
+
+    Shared by the clipping and distortion galleries (and any future gallery
+    whose demo table is a single `SignalSpec` per entry, read from
+    `entry["spec"]`, rather than a multi-component sum) -- each entry there
+    is a single named impairment demo, not a multi-component signal, so this
+    streams it exactly the way make_signal_gallery_gifs.py's build_kind()
+    does: one `stream()` generator per entry.
+
+    Returns (frames, first_frame_buffer, post_loop_buffer) -- the two buffers
+    are the raw voltage arrays (not images), for the seamless-loop check,
+    exactly like make_signal_gallery_gifs.build_kind().
+    """
+    # Local import: keeps this module importable (e.g. by tooling that just
+    # wants a gallery's table) without requiring scpi_control's own import
+    # chain to have already succeeded, mirroring build_kind()'s identical
+    # local import.
+    from scpi_control.signal_synth import SignalSpec, stream
+
+    sample_rate = entry["sample_rate"]
+    chunk_size = entry["chunk_size"]
+    window_samples = entry["window_samples"]
+    n_frames = entry["n_frames"]
+    entry_title = title_entry(entry)
+
+    spec = SignalSpec(**entry["spec"])
+    gen = stream(spec, sample_rate=sample_rate, chunk_size=chunk_size, start_time=0.0)
+    buffer = _prime_buffer(gen, window_samples)
+    first_buffer = buffer.copy()
+    t_ms = np.arange(window_samples) / sample_rate * 1e3
+
+    frames = []
+    for _ in range(n_frames):
+        frames.append(render_frame(t_ms, buffer, entry_title, style))
+        chunk = next(gen)
+        buffer = np.concatenate([buffer[chunk.size :], chunk])
+
+    return frames, first_buffer, buffer
+
+
+def run_gallery(entries: list, build_fn, filename_prefix: str) -> None:
+    """Shared `main()` body for all four make_*_gallery_gifs.py scripts.
+
+    For each entry: calls `build_fn(entry, style)`, seam-checks the result
+    when `entry["seam_checked"]`, writes the GIF to
+    `DEST_DIR / f"{filename_prefix}-{slug}.gif"` (slug is `entry["name"]` if
+    present, else `entry["kind"]`), and prints a one-line summary -- the
+    identical shape every gallery script's own `main()` used to duplicate.
+    """
+    # Local import for the same reason as build_single_spec_demo's.
+    from scpi_control.report_generator.models.plot_style import PlotStyle
+
+    style = PlotStyle()
+    if not entries:
+        raise RuntimeError("entries is empty -- nothing to render")
+
+    for entry in entries:
+        frames, first_buffer, post_loop_buffer = build_fn(entry, style)
+        seam_note = ""
+        if entry["seam_checked"]:
+            max_diff = _check_seamless(title_entry(entry), first_buffer, post_loop_buffer)
+            seam_note = f", seam {max_diff:.2e} V"
+
+        slug = entry.get("name") or entry.get("kind")
+        dest = DEST_DIR / f"{filename_prefix}-{slug}.gif"
+        durations = [entry["frame_ms"]] * len(frames)
+        size_kb = _write_gif(dest, frames, durations)
+        w, h = frames[0].size
+        print(f"wrote {dest} ({size_kb:.0f} KB, {len(frames)} frames, {w}x{h}{seam_note})")

--- a/scripts/media/make_clipping_gallery_gifs.py
+++ b/scripts/media/make_clipping_gallery_gifs.py
@@ -12,9 +12,10 @@ generator's own `PlotStyle`, so nothing here is hand-drawn.
 
 Unlike make_superposition_gallery_gifs.py, each demo here is a single
 `SignalSpec` (clipping is not a multi-component feature), so this script
-streams it exactly the way make_signal_gallery_gifs.py's build_kind() does --
-one `stream()` generator per entry -- rather than the parallel-multi-stream
-technique the superposition script needed.
+uses gallery_common.build_single_spec_demo() -- one `stream()` generator per
+entry, the same way make_signal_gallery_gifs.py's build_kind() streams a
+KINDS entry -- rather than the parallel-multi-stream technique the
+superposition script needed.
 
 Each animation is the same classic scrolling-scope loop as the other two
 galleries: a fixed-length sample buffer rolls left by one `stream()` chunk
@@ -23,9 +24,9 @@ spec's own frequency must divide the total time advanced across all frames
 (n_frames * chunk_size samples) into a whole number of cycles, exactly like
 the per-kind gallery's requirement -- clipping is a memoryless, per-sample
 nonlinearity, so it does not change the signal's period and does not break
-an otherwise-seamless loop. `main()` verifies this numerically and refuses
-to write a GIF (RuntimeError) if the wrap-around jump exceeds a tight
-tolerance.
+an otherwise-seamless loop. `run_gallery()` (in gallery_common.py) verifies
+this numerically and refuses to write a GIF (RuntimeError) if the
+wrap-around jump exceeds a tight tolerance.
 
 Resolves its own repo root from __file__, so it can be run from anywhere:
   python scripts/media/make_clipping_gallery_gifs.py
@@ -35,22 +36,19 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, Dict
 
-import numpy as np
-
-# Sibling-module import: make_signal_gallery_gifs.py already has the render
-# pipeline (frame drawing, seamless-loop check, palettized GIF writing) this
-# script needs unchanged, so it is imported rather than copy-pasted. Both
-# scripts live directly in scripts/media/ with no package __init__.py, so the
-# directory is put on sys.path explicitly rather than relying on the
-# interpreter having added it only because this file happened to be the one
-# invoked directly.
+# Sibling-module import: gallery_common.py has the render pipeline (frame
+# drawing, seamless-loop check, palettized GIF writing, main() body, and the
+# single-SignalSpec build helper) this script needs unchanged, so it is
+# imported rather than copy-pasted. Both scripts live directly in
+# scripts/media/ with no package __init__.py, so the directory is put on
+# sys.path explicitly rather than relying on the interpreter having added it
+# only because this file happened to be the one invoked directly.
 _MEDIA_DIR = Path(__file__).resolve().parent
 if str(_MEDIA_DIR) not in sys.path:
     sys.path.insert(0, str(_MEDIA_DIR))
 
-from make_signal_gallery_gifs import DEST_DIR, _check_seamless, _prime_buffer, _write_gif, render_frame  # noqa: E402
+from gallery_common import build_single_spec_demo, run_gallery  # noqa: E402
 
 # One entry per clipping/saturation demo. Kept as a plain literal list of
 # dicts (no loops, no computed fields, no SignalSpec(...) calls) so
@@ -68,8 +66,8 @@ from make_signal_gallery_gifs import DEST_DIR, _check_seamless, _prime_buffer, _
 # own "sine" entry: total advance = 30*4 = 120 samples = 120/120000 = 1 ms =
 # exactly one 1 kHz period. Clipping is a memoryless per-sample nonlinearity
 # applied on top of that sine, so it does not change the period and the loop
-# stays seamless -- verified empirically (`main()`'s _check_seamless call)
-# rather than merely assumed.
+# stays seamless -- verified empirically (run_gallery()'s seam check) rather
+# than merely assumed.
 # No type annotation on this assignment, for the same ast.Assign-only reason
 # as KINDS/COMBOS.
 DEMOS = [
@@ -98,71 +96,8 @@ DEMOS = [
 ]
 
 
-def _title_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
-    """A copy of `entry` with a "kind" field, for reusing render_frame/_check_seamless.
-
-    Both helpers were written for KINDS, where every entry has a top-level
-    "kind" and uses it as a frame title / in an error message. A DEMOS entry
-    keeps "kind" nested inside "spec" instead (see the module docstring), so
-    this substitutes a readable title derived from "name" -- the same
-    technique make_superposition_gallery_gifs.py's _title_entry uses.
-    """
-    return {**entry, "kind": entry["name"].replace("_", " ")}
-
-
-def build_demo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndarray]:
-    """Stream `entry`'s single SignalSpec and render its frames.
-
-    Returns (frames, first_frame_buffer, post_loop_buffer) -- the two buffers
-    are the raw voltage arrays (not images), for the seamless-loop check,
-    exactly like make_signal_gallery_gifs.build_kind().
-    """
-    # Local import: keeps this module importable (e.g. by tooling that just
-    # wants DEMOS) without requiring scpi_control's own import chain to have
-    # already succeeded, mirroring build_kind()'s identical local import.
-    from scpi_control.signal_synth import SignalSpec, stream
-
-    sample_rate = entry["sample_rate"]
-    chunk_size = entry["chunk_size"]
-    window_samples = entry["window_samples"]
-    n_frames = entry["n_frames"]
-    title_entry = _title_entry(entry)
-
-    spec = SignalSpec(**entry["spec"])
-    gen = stream(spec, sample_rate=sample_rate, chunk_size=chunk_size, start_time=0.0)
-    buffer = _prime_buffer(gen, window_samples)
-    first_buffer = buffer.copy()
-    t_ms = np.arange(window_samples) / sample_rate * 1e3
-
-    frames = []
-    for _ in range(n_frames):
-        frames.append(render_frame(t_ms, buffer, title_entry, style))
-        chunk = next(gen)
-        buffer = np.concatenate([buffer[chunk.size :], chunk])
-
-    return frames, first_buffer, buffer
-
-
 def main() -> None:
-    # Local import for the same reason as build_demo's.
-    from scpi_control.report_generator.models.plot_style import PlotStyle
-
-    style = PlotStyle()
-    if not DEMOS:
-        raise RuntimeError("DEMOS is empty -- nothing to render")
-
-    for entry in DEMOS:
-        frames, first_buffer, post_loop_buffer = build_demo(entry, style)
-        seam_note = ""
-        if entry["seam_checked"]:
-            max_diff = _check_seamless(_title_entry(entry), first_buffer, post_loop_buffer)
-            seam_note = f", seam {max_diff:.2e} V"
-
-        dest = DEST_DIR / f"clipping-{entry['name']}.gif"
-        durations = [entry["frame_ms"]] * len(frames)
-        size_kb = _write_gif(dest, frames, durations)
-        w, h = frames[0].size
-        print(f"wrote {dest} ({size_kb:.0f} KB, {len(frames)} frames, {w}x{h}{seam_note})")
+    run_gallery(DEMOS, build_single_spec_demo, "clipping")
 
 
 if __name__ == "__main__":

--- a/scripts/media/make_distortion_gallery_gifs.py
+++ b/scripts/media/make_distortion_gallery_gifs.py
@@ -13,9 +13,9 @@ hand-drawn.
 
 Like make_clipping_gallery_gifs.py (and unlike make_superposition_gallery_gifs.py),
 each demo here is a single `SignalSpec` (distortion is not a multi-component
-feature), so this script streams it exactly the way make_signal_gallery_gifs.py's
-build_kind() and make_clipping_gallery_gifs.py's build_demo() do -- one
-`stream()` generator per entry.
+feature), so this script streams it exactly the way
+gallery_common.build_single_spec_demo() does (the same helper
+make_clipping_gallery_gifs.py uses) -- one `stream()` generator per entry.
 
 Each animation is the same classic scrolling-scope loop as the other galleries:
 a fixed-length sample buffer rolls left by one `stream()` chunk per frame,
@@ -25,9 +25,9 @@ chunk_size samples) into a whole number of cycles, exactly like the per-kind
 and clipping galleries' requirement -- harmonic distortion via Chebyshev
 waveshaping is a memoryless, per-sample nonlinearity (T_2(u)=2u**2-1 for
 2nd/even, T_3(u)=4u**3-3u for 3rd/odd), so it does not change the signal's
-period and does not break an otherwise-seamless loop. `main()` verifies this
-numerically and refuses to write a GIF (RuntimeError) if the wrap-around jump
-exceeds a tight tolerance.
+period and does not break an otherwise-seamless loop. `run_gallery()` (in
+gallery_common.py) verifies this numerically and refuses to write a GIF
+(RuntimeError) if the wrap-around jump exceeds a tight tolerance.
 
 Resolves its own repo root from __file__, so it can be run from anywhere:
   python scripts/media/make_distortion_gallery_gifs.py
@@ -37,22 +37,19 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, Dict
 
-import numpy as np
-
-# Sibling-module import: make_signal_gallery_gifs.py already has the render
-# pipeline (frame drawing, seamless-loop check, palettized GIF writing) this
-# script needs unchanged, so it is imported rather than copy-pasted. Both
-# scripts live directly in scripts/media/ with no package __init__.py, so the
-# directory is put on sys.path explicitly rather than relying on the
-# interpreter having added it only because this file happened to be the one
-# invoked directly.
+# Sibling-module import: gallery_common.py has the render pipeline (frame
+# drawing, seamless-loop check, palettized GIF writing, main() body, and the
+# single-SignalSpec build helper) this script needs unchanged, so it is
+# imported rather than copy-pasted. Both scripts live directly in
+# scripts/media/ with no package __init__.py, so the directory is put on
+# sys.path explicitly rather than relying on the interpreter having added it
+# only because this file happened to be the one invoked directly.
 _MEDIA_DIR = Path(__file__).resolve().parent
 if str(_MEDIA_DIR) not in sys.path:
     sys.path.insert(0, str(_MEDIA_DIR))
 
-from make_signal_gallery_gifs import DEST_DIR, _check_seamless, _prime_buffer, _write_gif, render_frame  # noqa: E402
+from gallery_common import build_single_spec_demo, run_gallery  # noqa: E402
 
 # One entry per harmonic-distortion demo. Kept as a plain literal list of
 # dicts (no loops, no computed fields, no SignalSpec(...) calls) so
@@ -72,7 +69,7 @@ from make_signal_gallery_gifs import DEST_DIR, _check_seamless, _prime_buffer, _
 # = 30*4 = 120 samples = 120/120000 = 1 ms = exactly one 1 kHz period.
 # Harmonic distortion is a memoryless per-sample nonlinearity applied on top
 # of that sine, so it does not change the period and the loop stays seamless
-# -- verified empirically (`main()`'s _check_seamless call) rather than merely
+# -- verified empirically (run_gallery()'s seam check) rather than merely
 # assumed.
 #
 # ylim: with amplitude=1.0 and distortion_h2/h3=0.35, the worst-case sample
@@ -109,73 +106,8 @@ DEMOS = [
 ]
 
 
-def _title_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
-    """A copy of `entry` with a "kind" field, for reusing render_frame/_check_seamless.
-
-    Both helpers were written for KINDS, where every entry has a top-level
-    "kind" and uses it as a frame title / in an error message. A DEMOS entry
-    keeps "kind" nested inside "spec" instead (see the module docstring), so
-    this substitutes a readable title derived from "name" -- the same
-    technique make_superposition_gallery_gifs.py's and
-    make_clipping_gallery_gifs.py's _title_entry use.
-    """
-    return {**entry, "kind": entry["name"].replace("_", " ")}
-
-
-def build_demo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndarray]:
-    """Stream `entry`'s single SignalSpec and render its frames.
-
-    Returns (frames, first_frame_buffer, post_loop_buffer) -- the two buffers
-    are the raw voltage arrays (not images), for the seamless-loop check,
-    exactly like make_signal_gallery_gifs.build_kind() and
-    make_clipping_gallery_gifs.build_demo().
-    """
-    # Local import: keeps this module importable (e.g. by tooling that just
-    # wants DEMOS) without requiring scpi_control's own import chain to have
-    # already succeeded, mirroring build_kind()'s identical local import.
-    from scpi_control.signal_synth import SignalSpec, stream
-
-    sample_rate = entry["sample_rate"]
-    chunk_size = entry["chunk_size"]
-    window_samples = entry["window_samples"]
-    n_frames = entry["n_frames"]
-    title_entry = _title_entry(entry)
-
-    spec = SignalSpec(**entry["spec"])
-    gen = stream(spec, sample_rate=sample_rate, chunk_size=chunk_size, start_time=0.0)
-    buffer = _prime_buffer(gen, window_samples)
-    first_buffer = buffer.copy()
-    t_ms = np.arange(window_samples) / sample_rate * 1e3
-
-    frames = []
-    for _ in range(n_frames):
-        frames.append(render_frame(t_ms, buffer, title_entry, style))
-        chunk = next(gen)
-        buffer = np.concatenate([buffer[chunk.size :], chunk])
-
-    return frames, first_buffer, buffer
-
-
 def main() -> None:
-    # Local import for the same reason as build_demo's.
-    from scpi_control.report_generator.models.plot_style import PlotStyle
-
-    style = PlotStyle()
-    if not DEMOS:
-        raise RuntimeError("DEMOS is empty -- nothing to render")
-
-    for entry in DEMOS:
-        frames, first_buffer, post_loop_buffer = build_demo(entry, style)
-        seam_note = ""
-        if entry["seam_checked"]:
-            max_diff = _check_seamless(_title_entry(entry), first_buffer, post_loop_buffer)
-            seam_note = f", seam {max_diff:.2e} V"
-
-        dest = DEST_DIR / f"distortion-{entry['name']}.gif"
-        durations = [entry["frame_ms"]] * len(frames)
-        size_kb = _write_gif(dest, frames, durations)
-        w, h = frames[0].size
-        print(f"wrote {dest} ({size_kb:.0f} KB, {len(frames)} frames, {w}x{h}{seam_note})")
+    run_gallery(DEMOS, build_single_spec_demo, "distortion")
 
 
 if __name__ == "__main__":

--- a/scripts/media/make_signal_gallery_gifs.py
+++ b/scripts/media/make_signal_gallery_gifs.py
@@ -12,10 +12,17 @@ autoscale jitter). Frame count and chunk size are chosen per kind so the total
 time advanced across all frames is an exact integer number of that signal's
 own period (or, for "chirp", its sweep_time) -- so the last frame flows back
 into the first with no visible phase jump when the GIF loops (`loop=0`).
-`main()` verifies this numerically for every kind where it applies, and
-refuses to write a GIF (RuntimeError) if a "seamless" kind's wrap-around jump
-exceeds a tight tolerance. "dc" and "noise" have no cycle to align to and are
-exempt -- see SEAMLESS_TOLERANCE_V and the KINDS table below.
+`run_gallery()` (in gallery_common.py) verifies this numerically for every
+kind where it applies, and refuses to write a GIF (RuntimeError) if a
+"seamless" kind's wrap-around jump exceeds a tight tolerance. "dc" and
+"noise" have no cycle to align to and are exempt -- see
+gallery_common.SEAMLESS_TOLERANCE_V and the KINDS table below.
+
+The frame-rendering/GIF-writing pipeline this script uses is shared with its
+three sibling gallery scripts (make_superposition_gallery_gifs.py,
+make_clipping_gallery_gifs.py, make_distortion_gallery_gifs.py) via
+gallery_common.py, imported below. This script keeps its own KINDS table and
+build_kind() -- those are specific to per-kind signal rendering.
 
 Resolves its own repo root from __file__, so it can be run from anywhere:
   python scripts/media/make_signal_gallery_gifs.py
@@ -23,32 +30,24 @@ Resolves its own repo root from __file__, so it can be run from anywhere:
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
-from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.figure import Figure
 from PIL import Image
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-DEST_DIR = REPO_ROOT / "docs" / "images"
-SIZE_BUDGET_KB = 450
+# Sibling-module import: gallery_common.py has the render pipeline (frame
+# drawing, seamless-loop check, palettized GIF writing, main() body) shared
+# across all four make_*_gallery_gifs.py scripts. Both live directly in
+# scripts/media/ with no package __init__.py, so the directory is put on
+# sys.path explicitly rather than relying on the interpreter having added it
+# only because this file happened to be the one invoked directly.
+_MEDIA_DIR = Path(__file__).resolve().parent
+if str(_MEDIA_DIR) not in sys.path:
+    sys.path.insert(0, str(_MEDIA_DIR))
 
-FIG_SIZE_IN = (3.4, 1.9)  # inches
-DPI = 100  # -> 340x190 px frames
-PALETTE_COLORS = 48  # a single line + grid on white needs far fewer colours than the code-editor GIFs
-
-# How close the buffer just after the LAST frame's chunk must land to the
-# FIRST frame's buffer, in volts, for a "seamless" kind (see KINDS below).
-# Tight: everything at play here (SignalSpec generators, t0 bookkeeping in
-# stream()/synthesize()) is deterministic float64 arithmetic with no jitter
-# or impairments enabled, so a genuinely aligned loop reproduces to within a
-# few ULPs, not merely "close". A few micro-volts already means the frame
-# math is wrong, not that the tolerance was too strict.
-SEAMLESS_TOLERANCE_V = 1e-6
+from gallery_common import _prime_buffer, render_frame, run_gallery  # noqa: E402
 
 # One entry per scpi_control.signal_synth._GENERATORS kind. Kept as a plain
 # literal list of dicts (no loops, no computed fields, no SignalSpec(...)
@@ -202,43 +201,6 @@ KINDS = [
 ]
 
 
-def _prime_buffer(gen, window_samples: int) -> np.ndarray:
-    """Fill the rolling buffer with whole stream() chunks before rendering starts."""
-    chunks = [next(gen)]
-    total = chunks[0].size
-    while total < window_samples:
-        chunk = next(gen)
-        chunks.append(chunk)
-        total += chunk.size
-    buffer = np.concatenate(chunks)
-    if buffer.size != window_samples:
-        raise RuntimeError(f"buffer priming landed on {buffer.size} samples, expected exactly {window_samples} -- window_samples must be a multiple of chunk_size")
-    return buffer
-
-
-def render_frame(t_ms: np.ndarray, voltage: np.ndarray, entry: Dict[str, Any], style) -> Image.Image:
-    """Render one rolling-buffer frame to an in-memory RGB image."""
-    fig = Figure(figsize=FIG_SIZE_IN, dpi=DPI)
-    fig.patch.set_facecolor(style.background_color)
-    canvas = FigureCanvasAgg(fig)
-    ax = fig.add_subplot(111)
-
-    ax.plot(t_ms, voltage, color=style.waveform_color, linewidth=style.waveform_linewidth)
-    style.apply_to_axes(ax)
-
-    ax.set_xlim(t_ms[0], t_ms[-1])
-    ax.set_ylim(*entry["ylim"])
-    ax.set_xlabel("Time (ms)", fontsize=style.label_fontsize)
-    ax.set_ylabel("Voltage (V)", fontsize=style.label_fontsize)
-    ax.set_title(entry["kind"], fontsize=style.title_fontsize)
-    fig.tight_layout()
-
-    canvas.draw()
-    w, h = canvas.get_width_height()
-    img = Image.frombuffer("RGBA", (w, h), canvas.buffer_rgba(), "raw", "RGBA", 0, 1)
-    return img.convert("RGB")
-
-
 def build_kind(entry: Dict[str, Any], style) -> tuple[list[Image.Image], np.ndarray, np.ndarray]:
     """Stream `entry`'s signal and render its frames.
 
@@ -270,55 +232,8 @@ def build_kind(entry: Dict[str, Any], style) -> tuple[list[Image.Image], np.ndar
     return frames, first_buffer, buffer
 
 
-def _check_seamless(entry: Dict[str, Any], first_buffer: np.ndarray, post_loop_buffer: np.ndarray) -> float:
-    """Empirically verify the wrap-around jump, in volts. Raises if too large."""
-    max_diff = float(np.max(np.abs(post_loop_buffer - first_buffer)))
-    if max_diff > SEAMLESS_TOLERANCE_V:
-        raise RuntimeError(
-            f"{entry['kind']!r} is marked seam_checked but the buffer after "
-            f"{entry['n_frames']} frames differs from the first frame by up to "
-            f"{max_diff:.3e} V (tolerance {SEAMLESS_TOLERANCE_V:.0e} V) -- the "
-            "loop would show a visible jump; check sample_rate/chunk_size/n_frames"
-        )
-    return max_diff
-
-
-def _write_gif(dest: Path, frames: list[Image.Image], durations: list[int]) -> float:
-    palettised = [f.convert("P", palette=Image.ADAPTIVE, colors=PALETTE_COLORS) for f in frames]
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_name(dest.stem + ".tmp.gif")
-    try:
-        palettised[0].save(tmp, save_all=True, append_images=palettised[1:], duration=durations, loop=0, optimize=True, disposal=2)
-        size_kb = tmp.stat().st_size / 1024
-        if size_kb > SIZE_BUDGET_KB:
-            raise RuntimeError(f"{dest.name} is {size_kb:.0f} KB, over the {SIZE_BUDGET_KB} KB budget -- reduce frame count, dimensions, or palette depth")
-        os.replace(tmp, dest)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-    return size_kb
-
-
 def main() -> None:
-    # Local import for the same reason as build_kind's.
-    from scpi_control.report_generator.models.plot_style import PlotStyle
-
-    style = PlotStyle()
-    if not KINDS:
-        raise RuntimeError("KINDS is empty -- nothing to render")
-
-    for entry in KINDS:
-        frames, first_buffer, post_loop_buffer = build_kind(entry, style)
-        seam_note = ""
-        if entry["seam_checked"]:
-            max_diff = _check_seamless(entry, first_buffer, post_loop_buffer)
-            seam_note = f", seam {max_diff:.2e} V"
-
-        dest = DEST_DIR / f"signal-{entry['kind']}.gif"
-        durations = [entry["frame_ms"]] * len(frames)
-        size_kb = _write_gif(dest, frames, durations)
-        w, h = frames[0].size
-        print(f"wrote {dest} ({size_kb:.0f} KB, {len(frames)} frames, {w}x{h}{seam_note})")
+    run_gallery(KINDS, build_kind, "signal")
 
 
 if __name__ == "__main__":

--- a/scripts/media/make_superposition_gallery_gifs.py
+++ b/scripts/media/make_superposition_gallery_gifs.py
@@ -27,11 +27,12 @@ frames (n_frames * chunk_size samples) into a whole number of cycles -- the
 same requirement make_signal_gallery_gifs.py's docstring works out for
 "chirp", just applied to every component independently rather than to a
 single kind -- so the last frame flows back into the first with no visible
-phase jump. `main()` verifies this numerically and refuses to write a GIF
-(RuntimeError) if the wrap-around jump exceeds a tight tolerance. An entry
-with a non-periodic component (e.g. "noise", which has no cycle to align to
-and re-seeds every chunk anyway) is marked "seam_checked": False instead, the
-same way the per-kind gallery treats "dc" and "noise".
+phase jump. `run_gallery()` (in gallery_common.py) verifies this numerically
+and refuses to write a GIF (RuntimeError) if the wrap-around jump exceeds a
+tight tolerance. An entry with a non-periodic component (e.g. "noise", which
+has no cycle to align to and re-seeds every chunk anyway) is marked
+"seam_checked": False instead, the same way the per-kind gallery treats "dc"
+and "noise".
 
 Resolves its own repo root from __file__, so it can be run from anywhere:
   python scripts/media/make_superposition_gallery_gifs.py
@@ -45,8 +46,8 @@ from typing import Any, Dict
 
 import numpy as np
 
-# Sibling-module import: make_signal_gallery_gifs.py already has the render
-# pipeline (frame drawing, seamless-loop check, palettized GIF writing) this
+# Sibling-module import: gallery_common.py has the render pipeline (frame
+# drawing, seamless-loop check, palettized GIF writing, main() body) this
 # script needs unchanged, so it is imported rather than copy-pasted. Both
 # scripts live directly in scripts/media/ with no package __init__.py, so the
 # directory is put on sys.path explicitly rather than relying on the
@@ -56,7 +57,7 @@ _MEDIA_DIR = Path(__file__).resolve().parent
 if str(_MEDIA_DIR) not in sys.path:
     sys.path.insert(0, str(_MEDIA_DIR))
 
-from make_signal_gallery_gifs import DEST_DIR, _check_seamless, _prime_buffer, _write_gif, render_frame  # noqa: E402
+from gallery_common import _prime_buffer, render_frame, run_gallery, title_entry  # noqa: E402
 
 # One entry per superposition example. Kept as a plain literal list of dicts
 # (no loops, no computed fields, no SignalSpec(...)/SuperposedSignal(...)
@@ -142,17 +143,6 @@ COMBOS = [
 ]
 
 
-def _title_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
-    """A copy of `entry` with a "kind" field, for reusing render_frame/_check_seamless.
-
-    Both helpers were written for KINDS, where every entry has exactly one
-    "kind" and uses it as a frame title / in an error message. A COMBOS entry
-    sums two or more kinds, so there is no single one to use -- this
-    substitutes a readable name derived from "name" instead.
-    """
-    return {**entry, "kind": entry["name"].replace("_", " ")}
-
-
 def build_combo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndarray]:
     """Stream `entry`'s components in parallel, sum them, and render frames.
 
@@ -169,7 +159,7 @@ def build_combo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndar
     chunk_size = entry["chunk_size"]
     window_samples = entry["window_samples"]
     n_frames = entry["n_frames"]
-    title_entry = _title_entry(entry)
+    entry_title = title_entry(entry)
 
     specs = [SignalSpec(**component) for component in entry["components"]]
     gens = [stream(spec, sample_rate=sample_rate, chunk_size=chunk_size, start_time=0.0) for spec in specs]
@@ -180,7 +170,7 @@ def build_combo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndar
 
     frames = []
     for _ in range(n_frames):
-        frames.append(render_frame(t_ms, buffer, title_entry, style))
+        frames.append(render_frame(t_ms, buffer, entry_title, style))
         chunk = np.sum([next(gen) for gen in gens], axis=0)
         buffer = np.concatenate([buffer[chunk.size :], chunk])
 
@@ -188,25 +178,7 @@ def build_combo(entry: Dict[str, Any], style) -> tuple[list, np.ndarray, np.ndar
 
 
 def main() -> None:
-    # Local import for the same reason as build_combo's.
-    from scpi_control.report_generator.models.plot_style import PlotStyle
-
-    style = PlotStyle()
-    if not COMBOS:
-        raise RuntimeError("COMBOS is empty -- nothing to render")
-
-    for entry in COMBOS:
-        frames, first_buffer, post_loop_buffer = build_combo(entry, style)
-        seam_note = ""
-        if entry["seam_checked"]:
-            max_diff = _check_seamless(_title_entry(entry), first_buffer, post_loop_buffer)
-            seam_note = f", seam {max_diff:.2e} V"
-
-        dest = DEST_DIR / f"superposition-{entry['name']}.gif"
-        durations = [entry["frame_ms"]] * len(frames)
-        size_kb = _write_gif(dest, frames, durations)
-        w, h = frames[0].size
-        print(f"wrote {dest} ({size_kb:.0f} KB, {len(frames)} frames, {w}x{h}{seam_note})")
+    run_gallery(COMBOS, build_combo, "superposition")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Deferred cleanup from PR #174's review: the four `scripts/media/make_*_gallery_gifs.py` README GIF generators had grown three near-identical copies of the same render/seam-check/write-gif `main()` loop, plus a byte-identical `build_demo()` duplicated between the clipping and distortion scripts.

Extracted into new `scripts/media/gallery_common.py`:
- Shared constants/primitives (`DEST_DIR`, `_prime_buffer`, `render_frame`, `_check_seamless`, `_write_gif`), moved from `make_signal_gallery_gifs.py`
- `title_entry()` -- unifies three near-duplicate `_title_entry()` helpers
- `build_single_spec_demo()` -- replaces the duplicated `build_demo()` (clipping + distortion)
- `run_gallery()` -- replaces all four scripts' `main()` bodies

Pure behavior-preserving refactor, no table/README/test changes.

## Verification

- All 17 gallery GIFs regenerate byte-identical (`git status` shows zero diff on `docs/images/*.gif` after re-running all four scripts)
- `pytest tests/test_media_tour.py tests/test_signal_synth.py tests/test_signal_kinds.py tests/test_mock_synthesis.py` -- 188 passed
- `pytest -m "not slow" -n 8` -- 3000 passed, 61 skipped
- `black --check` / `flake8 --select=E9,F63,F7,F82` clean
- `/code-review main high` -- zero findings

## Test plan

- [x] Re-ran all four gallery scripts, confirmed byte-identical output
- [x] Full targeted + broad test sweep green
- [x] Independent code review, clean

https://claude.ai/code/session_01KvnXYppcP5viGfKbgdfXTr
