### PR TITLE
feat: warn on known trigger-source coercion via capability flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources.** `ModelCapability` gains two fields --
   `unreliable_trigger_sources: FrozenSet[str]` and
   `warns_on_disabled_trigger_channel: bool` -- populated for the SDS824X HD
-  (modern dialect): it silently lands `EX`/`EX5` on `LINE` with no error
-  queued, and silently coerces a disabled channel's selection to `LINE` the
-  same way. `Trigger.source`'s setter now logs a `logging.WARNING` before
+  (modern dialect): it silently coerces `EX` to `LINE`, and `EX5` is never
+  honored at all, with no error queued in either case; it also silently
+  coerces a disabled channel's selection to `LINE` the same way.
+  `Trigger.source`'s setter now logs a `logging.WARNING` before
   writing when the connected model is known to do this -- it never raises
   and never changes what gets sent to the instrument, so
   `scope.trigger.source` still must be read back to confirm what took. Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Trigger.source` warns instead of silently coercing known-bad trigger
+  sources.** `ModelCapability` gains two fields --
+  `unreliable_trigger_sources: FrozenSet[str]` and
+  `warns_on_disabled_trigger_channel: bool` -- populated for the SDS824X HD
+  (modern dialect): it silently lands `EX`/`EX5` on `LINE` with no error
+  queued, and silently coerces a disabled channel's selection to `LINE` the
+  same way. `Trigger.source`'s setter now logs a `logging.WARNING` before
+  writing when the connected model is known to do this -- it never raises
+  and never changes what gets sent to the instrument, so
+  `scope.trigger.source` still must be read back to confirm what took. Every
+  other model, including any not yet measured for this quirk, gets no
+  warning. The check is guarded by `isinstance(cap, ModelCapability)` so the
+  plain `unittest.mock.Mock()` scopes used throughout the trigger test suite
+  are unaffected.
+
 - **Harmonic distortion for mock signal synthesis.** `SignalSpec` gains
   `distortion_h2` and `distortion_h3` (fraction of `amplitude`, `0.0` = off),
   a kind-agnostic impairment -- like `noise_rms`/`clip_level` -- modeling a

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources.** `ModelCapability` gains two fields --
   `unreliable_trigger_sources: FrozenSet[str]` and
   `warns_on_disabled_trigger_channel: bool` -- populated for the SDS824X HD
-  (modern dialect): it silently lands `EX`/`EX5` on `LINE` with no error
-  queued, and silently coerces a disabled channel's selection to `LINE` the
-  same way. `Trigger.source`'s setter now logs a `logging.WARNING` before
+  (modern dialect): it silently coerces `EX` to `LINE`, and `EX5` is never
+  honored at all, with no error queued in either case; it also silently
+  coerces a disabled channel's selection to `LINE` the same way.
+  `Trigger.source`'s setter now logs a `logging.WARNING` before
   writing when the connected model is known to do this -- it never raises
   and never changes what gets sent to the instrument, so
   `scope.trigger.source` still must be read back to confirm what took. Every

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Trigger.source` warns instead of silently coercing known-bad trigger
+  sources.** `ModelCapability` gains two fields --
+  `unreliable_trigger_sources: FrozenSet[str]` and
+  `warns_on_disabled_trigger_channel: bool` -- populated for the SDS824X HD
+  (modern dialect): it silently lands `EX`/`EX5` on `LINE` with no error
+  queued, and silently coerces a disabled channel's selection to `LINE` the
+  same way. `Trigger.source`'s setter now logs a `logging.WARNING` before
+  writing when the connected model is known to do this -- it never raises
+  and never changes what gets sent to the instrument, so
+  `scope.trigger.source` still must be read back to confirm what took. Every
+  other model, including any not yet measured for this quirk, gets no
+  warning. The check is guarded by `isinstance(cap, ModelCapability)` so the
+  plain `unittest.mock.Mock()` scopes used throughout the trigger test suite
+  are unaffected.
+
 - **Harmonic distortion for mock signal synthesis.** `SignalSpec` gains
   `distortion_h2` and `distortion_h3` (fraction of `amplitude`, `0.0` = off),
   a kind-agnostic impairment -- like `noise_rms`/`clip_level` -- modeling a

--- a/docs/user-guide/trigger-control.md
+++ b/docs/user-guide/trigger-control.md
@@ -177,7 +177,12 @@ scope.trigger.source = "EX5"   # 5V external input (if available)
     the current source is `LINE`. Other modern-dialect scopes, such as the
     SDS2000X+, do have a working external input.
 
-    Read the value back if your measurement depends on it:
+    On a model with this quirk measured and recorded (currently just the
+    SDS824X HD), `scope.trigger.source = "EX"` logs a `logging.WARNING`
+    instead of writing silently — it does not raise and does not change what
+    gets sent to the instrument. Any model that hasn't been measured for this
+    quirk still writes with no warning, so read the value back if your
+    measurement depends on it:
 
     ```python
     scope.trigger.source = "EX"

--- a/scpi_control/models.py
+++ b/scpi_control/models.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import FrozenSet, List, Optional
 
 from scpi_control import exceptions
 
@@ -33,6 +33,8 @@ class ModelCapability:
     vendor: str = "siglent"  # Instrument vendor: "siglent", "tektronix", or "lecroy"
     horiz_divisions: int = 14  # Screen grid width in divisions (Siglent scopes use 14)
     vert_divisions: int = 8  # Screen grid height in divisions
+    unreliable_trigger_sources: FrozenSet[str] = frozenset()  # Sources this model is known to silently coerce away regardless of channel state (e.g. no EX input)
+    warns_on_disabled_trigger_channel: bool = False  # True if selecting a disabled channel as trigger source is known to silently coerce to LINE on this model
 
     def __str__(self) -> str:
         """String representation of model capability."""
@@ -83,6 +85,11 @@ MODEL_REGISTRY = {
         supported_decode_types=["I2C", "SPI", "UART", "CAN", "LIN", "I2S"],
         scpi_variant="hd_series",
         dialect="modern",
+        # Measured on firmware 3.8.12.1.1.3.6, 2026-08-04 -- see trigger.py's
+        # Trigger.source setter docstring and scpi_commands.supported_trigger_sources
+        # for the full writeup. No error is queued in any of these cases.
+        unreliable_trigger_sources=frozenset({"EX", "EX5"}),
+        warns_on_disabled_trigger_channel=True,
     ),  # 1 GSa/s  # 100 Mpts
     "SDS804X HD": ModelCapability(
         model_name="SDS804X HD",

--- a/scpi_control/trigger.py
+++ b/scpi_control/trigger.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Optional, Union
 
 from scpi_control import exceptions
+from scpi_control.models import ModelCapability
 from scpi_control.scpi_commands import (
     _MODE_ALIASES,
     _PUBLIC_TRIGGER_SOURCES,
@@ -174,8 +175,15 @@ class Trigger:
 
         Warning:
             A scope may silently COERCE this rather than reject it, so a write
-            that raises nothing is not proof the source took. Measured on an
-            SDS824X HD (modern) 2026-08-04, with no error queued in any case:
+            that raises nothing is not proof the source took. For models with
+            measured quirks (see ``ModelCapability.unreliable_trigger_sources``
+            and ``.warns_on_disabled_trigger_channel``), this setter logs a
+            warning before writing. For everything else -- including any
+            model nobody has measured yet -- no warning fires, and
+            ``scope.trigger.source`` must be read back to confirm what took.
+
+            Measured on an SDS824X HD (modern) 2026-08-04, with no error
+            queued in any case:
 
             - Selecting a channel that is switched OFF lands on ``LINE``. Turn
               the channel on first (``scope.channel2.enable()``).
@@ -186,10 +194,10 @@ class Trigger:
 
             ``scope.capabilities.trigger_sources`` reports what the DRIVER can
             send for the dialect, not what the attached model physically has.
-            When it matters, read ``scope.trigger.source`` back and compare.
         """
         channel = self._normalize_source(channel)
         channel = normalize_token(channel, parameter="trigger source", valid=_PUBLIC_TRIGGER_SOURCES, dialect=self._dialect)
+        self._warn_if_unreliable_source(channel)
 
         if not is_flat_trigger(self._dialect):
             self._scope.write(self._cmd("set_trigger_source", src=channel_token(self._dialect, channel)))
@@ -202,6 +210,33 @@ class Trigger:
             wire_type = trigger_type_to_wire(self._dialect, current_type)
             self._scope.write(self._cmd("set_trigger_select", type=wire_type, src=channel))
         logger.info(f"Trigger source set to {channel}")
+
+    def _warn_if_unreliable_source(self, channel: str) -> None:
+        """Log a warning if `channel` is known to be silently coerced.
+
+        Guarded by isinstance rather than getattr-with-default: a plain
+        Mock() (used throughout tests/dialect_helpers.py) auto-vivifies any
+        attribute access, so a missing-attribute default would never trigger
+        -- only a real ModelCapability instance carries meaningful flags.
+        """
+        cap = getattr(self._scope, "model_capability", None)
+        if not isinstance(cap, ModelCapability):
+            return
+        if channel in cap.unreliable_trigger_sources:
+            logger.warning(
+                f"{cap.model_name} is known to silently not honor trigger source "
+                f"{channel!r} (no error is queued). Read scope.trigger.source back "
+                f"to confirm what actually took effect."
+            )
+            return
+        if cap.warns_on_disabled_trigger_channel and channel.startswith("C"):
+            ch = self._scope.get_channel(int(channel[1:]))
+            if ch is not None and not ch.enabled:
+                logger.warning(
+                    f"{cap.model_name} silently coerces trigger source {channel!r} "
+                    f"to LINE while that channel is disabled (no error is queued). "
+                    f"Enable the channel first, or read scope.trigger.source back."
+                )
 
     def set_source(self, channel: Union[int, str]) -> None:
         """Convenience wrapper to set trigger source."""

--- a/scpi_control/trigger.py
+++ b/scpi_control/trigger.py
@@ -224,14 +224,19 @@ class Trigger:
             return
         if channel in cap.unreliable_trigger_sources:
             logger.warning(
-                f"{cap.model_name} is known to silently not honor trigger source "
-                f"{channel!r} (no error is queued). Read scope.trigger.source back "
-                f"to confirm what actually took effect."
+                f"{cap.model_name} is known to silently not honor trigger source " f"{channel!r} (no error is queued). Read scope.trigger.source back " f"to confirm what actually took effect."
             )
             return
         if cap.warns_on_disabled_trigger_channel and channel.startswith("C"):
-            ch = self._scope.get_channel(int(channel[1:]))
-            if ch is not None and not ch.enabled:
+            # Channel.enabled issues a live query(); this check is advisory
+            # only (never load-bearing), so a query failure here must not
+            # block the actual trigger-source write below.
+            try:
+                ch = self._scope.get_channel(int(channel[1:]))
+                disabled = ch is not None and not ch.enabled
+            except Exception:
+                return
+            if disabled:
                 logger.warning(
                     f"{cap.model_name} silently coerces trigger source {channel!r} "
                     f"to LINE while that channel is disabled (no error is queued). "

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,36 @@
+"""Tests for scpi_control.models.ModelCapability quirk-flag defaults."""
+
+from scpi_control.models import MODEL_REGISTRY, ModelCapability
+
+
+class TestTriggerQuirkFlags:
+    """Trigger-source coercion capability flags (pilot: SDS824X HD only)."""
+
+    def test_sds824x_hd_flags_known_unreliable_sources(self):
+        cap = MODEL_REGISTRY["SDS824X HD"]
+        assert cap.unreliable_trigger_sources == frozenset({"EX", "EX5"})
+        assert cap.warns_on_disabled_trigger_channel is True
+
+    def test_unmeasured_model_keeps_default_flags(self):
+        # SDS804X HD has not been measured for this quirk -- must not
+        # inherit SDS824X HD's flags or invent a claim about its hardware.
+        cap = MODEL_REGISTRY["SDS804X HD"]
+        assert cap.unreliable_trigger_sources == frozenset()
+        assert cap.warns_on_disabled_trigger_channel is False
+
+    def test_flags_default_to_unflagged_for_a_fresh_capability(self):
+        cap = ModelCapability(
+            model_name="FAKE",
+            series="Test",
+            num_channels=4,
+            max_sample_rate=1.0,
+            memory_depth=1000,
+            bandwidth_mhz=100,
+            has_math_channels=False,
+            has_fft=False,
+            has_protocol_decode=False,
+            supported_decode_types=[],
+            scpi_variant="standard",
+        )
+        assert cap.unreliable_trigger_sources == frozenset()
+        assert cap.warns_on_disabled_trigger_channel is False

--- a/tests/test_trigger_coercion_warnings.py
+++ b/tests/test_trigger_coercion_warnings.py
@@ -1,0 +1,109 @@
+"""Pilot coverage: Trigger.source warns instead of silently coercing.
+
+Covers the two SDS824X HD quirks encoded in ModelCapability
+(unreliable_trigger_sources, warns_on_disabled_trigger_channel) and proves
+the warning path is a no-op for models/test-doubles that don't carry a
+real ModelCapability -- the existing dual-dialect trigger test suites use
+plain unittest.mock.Mock() scopes (see tests/dialect_helpers.py), which
+must keep passing unchanged.
+"""
+
+import dataclasses
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from scpi_control.models import MODEL_REGISTRY
+from scpi_control.trigger import Trigger
+from tests.dialect_helpers import make_dialect_scope
+
+
+def _sds824x_hd_scope(channel_enabled: bool = True):
+    scope = make_dialect_scope("modern")
+    scope.model_capability = MODEL_REGISTRY["SDS824X HD"]
+    scope.get_channel = Mock(return_value=Mock(enabled=channel_enabled))
+    return scope
+
+
+class TestUnreliableSourceWarnings:
+    def test_setting_ex_warns(self, caplog):
+        scope = _sds824x_hd_scope()
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "EX"
+        assert any("EX" in r.message and "SDS824X HD" in r.message for r in caplog.records)
+        # The write is unchanged regardless of the warning.
+        scope.write.assert_called_once_with(":TRIGger:EDGE:SOURce EX")
+
+    def test_setting_ex5_warns(self, caplog):
+        scope = _sds824x_hd_scope()
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "EX5"
+        assert any("EX5" in r.message for r in caplog.records)
+
+    def test_setting_line_does_not_warn(self, caplog):
+        scope = _sds824x_hd_scope()
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "LINE"
+        assert caplog.records == []
+
+
+class TestDisabledChannelWarnings:
+    def test_disabled_channel_warns(self, caplog):
+        scope = _sds824x_hd_scope(channel_enabled=False)
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "C2"
+        assert any("C2" in r.message and "disabled" in r.message for r in caplog.records)
+        scope.get_channel.assert_called_once_with(2)
+
+    def test_enabled_channel_does_not_warn(self, caplog):
+        scope = _sds824x_hd_scope(channel_enabled=True)
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "C2"
+        assert caplog.records == []
+
+
+class TestNoFlagsNoWarning:
+    def test_model_without_flags_set_does_not_warn(self, caplog):
+        # SDS804X HD has never been measured for this quirk -- flags default off.
+        scope = make_dialect_scope("modern")
+        scope.model_capability = MODEL_REGISTRY["SDS804X HD"]
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "EX"
+        assert caplog.records == []
+
+    def test_flags_cleared_on_copy_does_not_warn(self, caplog):
+        # Same underlying model, flags explicitly cleared -- proves the
+        # warning is driven by the flags, not by the model name.
+        cleared = dataclasses.replace(
+            MODEL_REGISTRY["SDS824X HD"],
+            unreliable_trigger_sources=frozenset(),
+            warns_on_disabled_trigger_channel=False,
+        )
+        scope = make_dialect_scope("modern")
+        scope.model_capability = cleared
+        scope.get_channel = Mock(return_value=Mock(enabled=False))
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "EX"
+            trigger.source = "C2"
+        assert caplog.records == []
+
+    def test_plain_mock_model_capability_does_not_warn_or_crash(self, caplog):
+        # tests/dialect_helpers.make_dialect_scope leaves model_capability as
+        # a plain unittest.mock.Mock (only .num_channels is set). This must
+        # not raise -- it's the exact shape used across the existing trigger
+        # test suites (e.g. TestTriggerModernDialect in
+        # tests/test_trigger_comprehensive.py).
+        scope = make_dialect_scope("modern")
+        trigger = Trigger(scope)
+        with caplog.at_level(logging.WARNING):
+            trigger.source = "EX"
+            trigger.source = "C2"
+        assert caplog.records == []

--- a/tests/test_trigger_coercion_warnings.py
+++ b/tests/test_trigger_coercion_warnings.py
@@ -12,8 +12,6 @@ import dataclasses
 import logging
 from unittest.mock import Mock
 
-import pytest
-
 from scpi_control.models import MODEL_REGISTRY
 from scpi_control.trigger import Trigger
 from tests.dialect_helpers import make_dialect_scope


### PR DESCRIPTION
## Description

Pilot for moving known SCPI hardware quirks from comment-only documentation into typed, driver-consumed `ModelCapability` flags. This PR migrates exactly one quirk: the SDS824X HD's silent trigger-source coercion (`EX`/`EX5` never take, and a disabled channel is coerced to `LINE`), already measured and documented in `trigger.py`/`scpi_commands.py` comments but never acted on by the driver.

## Related Issues

Fixes #

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Changes Made

- Add `unreliable_trigger_sources: FrozenSet[str]` and `warns_on_disabled_trigger_channel: bool` to `ModelCapability` (`scpi_control/models.py`), populated only for `"SDS824X HD"` — every other registry entry keeps safe defaults until measured.
- Wire both flags into `Trigger.source`'s setter (`scpi_control/trigger.py`): it now logs a `logger.warning(...)` before writing a trigger source the connected model is known to silently coerce, without changing what gets written to the instrument.
- Guard the consumer with `isinstance(cap, ModelCapability)` (not a bare `is None`/truthy check) so it's a safe no-op against the plain `unittest.mock.Mock()` scopes used throughout the existing trigger test suite.
- Wrap the disabled-channel check's live instrument query in a `try/except` so a query failure degrades to "can't check" rather than blocking the write — this mechanism is advisory only, per the design spec.
- Update the `Trigger.source` docstring and `docs/user-guide/trigger-control.md` to describe the new warning while preserving "read it back" guidance for unmeasured models.
- CHANGELOG entry (mirrored to `docs/about/changelog.md`).

Design spec: `docs/superpowers/specs/2026-09-02-trigger-quirk-capability-flags-design.md` (local, not committed — this repo's `docs/superpowers/` convention is untracked working notes).

## Testing

- [x] Tests pass locally (`pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [x] All CI checks pass (black, flake8 on new files, full fast suite)

### Test Details

**Test environment:**

- OS: Windows 11
- Python version: 3.9+ (repo floor)
- Oscilloscope model: N/A (unit tests against mocks; hardware facts encoded here were previously measured on a real SDS824X HD, cited in the code)

**Test results:**

```
3011 passed, 61 skipped (pytest -m "not slow" -n 8), up from a 3000-passed baseline (+11 new tests)
black --check --line-length 200 scpi_control/ examples/  ->  clean
flake8 --select=F401 on new test file -> clean
```

New tests: `tests/test_models.py` (capability flag defaults/values), `tests/test_trigger_coercion_warnings.py` (warning fires for `EX`/`EX5`/disabled-channel, does not fire for `LINE`/enabled channel/unflagged models/plain-Mock test doubles), plus a mutation check (verified during development, not committed) proving the new tests fail when the flags are cleared.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

This is a pilot. If it holds up in review, the same pattern (measured facts on `ModelCapability`, `isinstance`-guarded consumer) is intended to extend to three other known quirks that are explicitly out of scope here: `code_per_div` sharing, the `:WAVeform:POINt` trap, and the SPD1000X OVP fall-through. A final whole-branch review flagged that those three are *behavior-affecting* rather than advisory, so the field-naming convention (`warns_on_disabled_trigger_channel` names the driver's reaction, not the hardware fact) should be revisited before that follow-up work, and `ModelCapability`'s flat field list is worth nesting into a `quirks` sub-dataclass once a second quirk lands.

https://claude.ai/code/session_01JADNk6BTZoHFRgtSQSfpXe
